### PR TITLE
Add bin/setup to install esprima

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,6 @@
+#!/usr/bin/env sh
+
+set -f
+
+npm install esprima
+bundle install

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -49,7 +49,7 @@ module CC::Engine::Analyzers::Javascript
       end
 
       def engine_conf
-        { 'config' => { 'javascript' => { 'mass_threshold' => 4 } } }
+        { 'config' => { 'javascript' => { 'mass_threshold' => 2 } } }
       end
     end
   end


### PR DESCRIPTION
The Node duplicaiton analyzer depends on `esprima` but isn't explicit
about this being a requirement or provide a setup script to get the
environment properly setup.

This adds a basic bin/setup script to install esprima and bundle gems.