### PR TITLE
Use correct config path to languages

### DIFF
--- a/lib/cc/engine/duplication.rb
+++ b/lib/cc/engine/duplication.rb
@@ -42,7 +42,11 @@ module CC
       end
 
       def languages
-        Array(engine_config['languages'] || DEFAULT_LANGUAGE)
+        config_languages = engine_config.
+          fetch("config", {}).
+          fetch("languages", DEFAULT_LANGUAGE)
+
+        Array(config_languages)
       end
     end
   end


### PR DESCRIPTION
The existing code was using `engine_config["languages"]` which is
incorrect. This needs to point to `engine_config["config"]["languages"]`
to work properly.