### PR TITLE
Make base point values language specific

### DIFF
--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -15,6 +15,7 @@ module CC
             "**/*.jsx"
           ]
           DEFAULT_MASS_THRESHOLD = 40
+          BASE_POINTS = 3000
 
           def initialize(engine_config:, directory:)
             @engine_config = engine_config
@@ -29,6 +30,10 @@ module CC
 
           def mass_threshold
             engine_config.fetch("config", {}).fetch("javascript", {}).fetch("mass_threshold", DEFAULT_MASS_THRESHOLD)
+          end
+
+          def base_points
+            BASE_POINTS
           end
 
           private

--- a/lib/cc/engine/analyzers/javascript/node.rb
+++ b/lib/cc/engine/analyzers/javascript/node.rb
@@ -5,7 +5,7 @@ module CC
     module Analyzers
       module Javascript
         class Node < CC::Engine::Analyzers::Node
-          SCRUB_PROPERTIES = ["type", "start", "end"]
+          SCRUB_PROPERTIES = %w[type start end]
 
           private
 

--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -14,6 +14,7 @@ module CC
             "**/*.module"
           ]
           DEFAULT_MASS_THRESHOLD = 10
+          BASE_POINTS = 4_000
 
           attr_reader :directory, :engine_config, :io
 
@@ -30,6 +31,10 @@ module CC
 
           def mass_threshold
             engine_config.fetch('config', {}).fetch('php', {}).fetch('mass_threshold', DEFAULT_MASS_THRESHOLD)
+          end
+
+          def base_points
+            BASE_POINTS
           end
 
           private

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -11,7 +11,10 @@ module CC
         class Main
           LANGUAGE = "python"
           DEFAULT_PATHS = ["**/*.py"]
-          DEFAULT_MASS_THRESHOLD = 50
+          DEFAULT_MASS_THRESHOLD = 40
+          BASE_POINTS = 1000
+          LANGUAGE = "python"
+          DEFAULT_PATHS = ["**/*.py"]
 
           def initialize(directory:, engine_config:)
             @directory = directory
@@ -26,6 +29,10 @@ module CC
 
           def mass_threshold
             engine_config.fetch("config", {}).fetch("python", {}).fetch("mass_threshold", DEFAULT_MASS_THRESHOLD)
+          end
+
+          def base_points
+            BASE_POINTS
           end
 
           private

--- a/lib/cc/engine/analyzers/python/node.rb
+++ b/lib/cc/engine/analyzers/python/node.rb
@@ -5,7 +5,7 @@ module CC
     module Analyzers
       module Python
         class Node < CC::Engine::Analyzers::Node
-          SCRUB_PROPERTIES = ["_type", "attributes"].freeze
+          SCRUB_PROPERTIES = %w[_type attributes ctx].freeze
 
           private
 

--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -46,7 +46,7 @@ module CC
 
         def new_violation(issue)
           hashes = flay.hashes[issue.structural_hash]
-          Violation.new(issue, hashes, directory).format
+          Violation.new(language_strategy.base_points, issue, hashes, directory).format
         end
 
         def flay_options

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -17,6 +17,7 @@ module CC
 
           ]
           DEFAULT_MASS_THRESHOLD = 10
+          BASE_POINTS = 10_000
           TIMEOUT = 10
 
           def initialize(directory:, engine_config:)
@@ -32,6 +33,10 @@ module CC
 
           def mass_threshold
             engine_config.fetch("config", {}).fetch("ruby", {}).fetch("mass_threshold", DEFAULT_MASS_THRESHOLD)
+          end
+
+          def base_points
+            BASE_POINTS
           end
 
           private

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -2,11 +2,10 @@ module CC
   module Engine
     module Analyzers
       class Violation
-        BASE_POINTS = 10_000
-
         attr_reader :issue
 
-        def initialize(issue, hashes, directory)
+        def initialize(base_points, issue, hashes, directory)
+          @base_points = base_points
           @issue = issue
           @hashes = hashes
           @directory = directory
@@ -27,7 +26,7 @@ module CC
 
         private
 
-        attr_reader :hashes, :directory
+        attr_reader :base_points, :hashes, :directory
 
         def current_sexp
           @location ||= hashes.first
@@ -46,7 +45,7 @@ module CC
         end
 
         def calculate_points
-          BASE_POINTS * issue.mass
+          base_points * issue.mass
         end
 
         def format_location

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -36,7 +36,7 @@ module CC::Engine::Analyzers::Javascript
       end
 
       def printed_issue
-        issue = {"type":"issue","check_name":"Identical code","description":"Duplication found in ExpressionStatement","categories":["Duplication"],"location":{"path":"foo.js","lines":{"begin":1,"end":1}},"remediation_points":1260000, "other_locations":[{"path":"foo.js","lines":{"begin":2,"end":2}},{"path":"foo.js","lines":{"begin":3,"end":3}}], "content":{"body": read_up}}
+        issue = {"type":"issue","check_name":"Identical code","description":"Duplication found in ExpressionStatement","categories":["Duplication"],"location":{"path":"foo.js","lines":{"begin":1,"end":1}},"remediation_points":378000, "other_locations":[{"path":"foo.js","lines":{"begin":2,"end":2}},{"path":"foo.js","lines":{"begin":3,"end":3}}], "content":{"body": read_up}}
         issue.to_json + "\0\n"
       end
 

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -49,7 +49,7 @@ module CC::Engine::Analyzers::Php
       end
 
       def printed_issue
-        issue = {"type":"issue","check_name":"Identical code","description":"Duplication found in function","categories":["Duplication"],"location":{"path":"foo.php","lines":{"begin":2,"end":6}},"remediation_points":440000,"other_locations":[{"path":"foo.php","lines":{"begin":10,"end":14}}],"content":{"body": read_up}}
+        issue = {"type":"issue","check_name":"Identical code","description":"Duplication found in function","categories":["Duplication"],"location":{"path":"foo.php","lines":{"begin":2,"end":6}},"remediation_points":176000,"other_locations":[{"path":"foo.php","lines":{"begin":10,"end":14}}],"content":{"body": read_up}}
         issue.to_json + "\0\n"
       end
 

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -35,7 +35,7 @@ print("Hello", "python")
       end
 
       def printed_issue
-        issue = {"type":"issue","check_name":"Identical code","description":"Duplication found in Print","categories":["Duplication"],"location":{"path":"foo.py","lines":{"begin":1,"end":1}},"remediation_points":990000, "other_locations":[{"path":"foo.py","lines":{"begin":2,"end":2}},{"path":"foo.py","lines":{"begin":3,"end":3}}], "content":{"body": read_up}}
+        issue = {"type":"issue","check_name":"Identical code","description":"Duplication found in Print","categories":["Duplication"],"location":{"path":"foo.py","lines":{"begin":1,"end":1}},"remediation_points":81000, "other_locations":[{"path":"foo.py","lines":{"begin":2,"end":2}},{"path":"foo.py","lines":{"begin":3,"end":3}}], "content":{"body": read_up}}
         issue.to_json + "\0\n"
       end
 


### PR DESCRIPTION
This extracts the base points to be a responsibility of each analyzer to
provide since each language can have different needs based on the
generated s-expressions.

This also puts us in a good place if we decide to make points part of
the configuration.