### PR TITLE
Make config fetching safer

### DIFF
--- a/lib/cc/engine/analyzers/file_list.rb
+++ b/lib/cc/engine/analyzers/file_list.rb
@@ -30,14 +30,21 @@ module CC
         end
 
         def engine_paths
-          engine_language =  engine_config.
-            fetch("config", {}).
-            fetch("languages", {}).
-            fetch(language, {})
-
-          if engine_language.is_a?(Hash)
-            engine_language["paths"]
+          if current_language.is_a?(Hash)
+            current_language["paths"]
           end
+        end
+
+        def current_language
+          if engine_languages.is_a?(Hash)
+            @current_language ||= engine_languages.fetch(language, {})
+          end
+        end
+
+        def engine_languages
+          @engine_language ||= engine_config.
+            fetch("config", {}).
+            fetch("languages", {})
         end
 
         def excluded_files

--- a/lib/cc/engine/duplication.rb
+++ b/lib/cc/engine/duplication.rb
@@ -47,7 +47,11 @@ module CC
           fetch("config", {}).
           fetch("languages", DEFAULT_LANGUAGE)
 
-        Array(config_languages)
+        if config_languages.is_a?(Hash)
+          config_languages.keys
+        else
+          Array(config_languages)
+        end
       end
     end
   end

--- a/spec/cc/engine/analyzers/file_list_spec.rb
+++ b/spec/cc/engine/analyzers/file_list_spec.rb
@@ -41,6 +41,23 @@ module CC::Engine::Analyzers
 
         assert_equal file_list.files, ["#{@tmp_dir}/foo.ex"]
       end
+
+      it "returns files from default_paths when languages is an array" do
+        file_list = ::CC::Engine::Analyzers::FileList.new(
+          directory: @tmp_dir,
+          engine_config: {
+            "config" => {
+              "languages" => [
+                "elixir"
+              ],
+            },
+          },
+          default_paths: ["**/*.js", "**/*.jsx"],
+          language: "javascript",
+        )
+
+        assert_equal file_list.files, ["#{@tmp_dir}/foo.js", "#{@tmp_dir}/foo.jsx"]
+      end
     end
   end
 end


### PR DESCRIPTION
The current code makes a few assumptions about the format of your
`.codeclimate.yml` which can cause the engine to crash.

This changes the way we fetch the configuration to consider that not
only may the keys not be present, but they might also not always be the
type we expect.