### PR TITLE
Add engine_config class

### DIFF
--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -1,0 +1,58 @@
+module CC
+  module Engine
+    module Analyzers
+      class EngineConfig
+        def initialize(hash)
+          @config = normalize(hash)
+        end
+
+        def exclude_paths
+          config.fetch("exclude_paths", [])
+        end
+
+        def languages
+          config.fetch("languages", {})
+        end
+
+        def mass_threshold_for(language)
+          fetch_language(language).fetch("mass_threshold", nil)
+        end
+
+        def paths_for(language)
+          fetch_language(language).fetch("paths", nil)
+        end
+
+        private
+
+        attr_reader :config
+
+        def fetch_language(language)
+          config.
+            fetch("languages", {}).
+            fetch(language, {})
+        end
+
+        def normalize(hash)
+          hash.tap do |config|
+            languages = config.fetch("config", {}).fetch("languages", {})
+            config["languages"] = build_language_config(languages)
+          end
+        end
+
+        def build_language_config(languages)
+          if languages.is_a?(Array)
+            languages.each_with_object({}) do |language, map|
+              map[language.downcase] = {}
+            end
+          elsif languages.is_a?(Hash)
+            languages.each_with_object({}) do |(key, value), map|
+              map[key.downcase] = value
+            end
+          else
+            {}
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/engine/analyzers/file_list.rb
+++ b/lib/cc/engine/analyzers/file_list.rb
@@ -30,21 +30,7 @@ module CC
         end
 
         def engine_paths
-          if current_language.is_a?(Hash)
-            current_language["paths"]
-          end
-        end
-
-        def current_language
-          if engine_languages.is_a?(Hash)
-            @current_language ||= engine_languages.fetch(language, {})
-          end
-        end
-
-        def engine_languages
-          @engine_language ||= engine_config.
-            fetch("config", {}).
-            fetch("languages", {})
+          @engine_config.paths_for(language)
         end
 
         def excluded_files
@@ -52,7 +38,7 @@ module CC
         end
 
         def excluded_paths
-          Array(engine_config["exclude_paths"])
+          engine_config.exclude_paths
         end
       end
     end

--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -29,7 +29,7 @@ module CC
           end
 
           def mass_threshold
-            engine_config.fetch("config", {}).fetch("javascript", {}).fetch("mass_threshold", DEFAULT_MASS_THRESHOLD)
+            engine_config.mass_threshold_for(LANGUAGE) || DEFAULT_MASS_THRESHOLD
           end
 
           def base_points

--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -30,7 +30,7 @@ module CC
           end
 
           def mass_threshold
-            engine_config.fetch('config', {}).fetch('php', {}).fetch('mass_threshold', DEFAULT_MASS_THRESHOLD)
+            engine_config.mass_threshold_for(LANGUAGE) || DEFAULT_MASS_THRESHOLD
           end
 
           def base_points

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -13,8 +13,6 @@ module CC
           DEFAULT_PATHS = ["**/*.py"]
           DEFAULT_MASS_THRESHOLD = 40
           BASE_POINTS = 1000
-          LANGUAGE = "python"
-          DEFAULT_PATHS = ["**/*.py"]
 
           def initialize(directory:, engine_config:)
             @directory = directory
@@ -28,7 +26,7 @@ module CC
           end
 
           def mass_threshold
-            engine_config.fetch("config", {}).fetch("python", {}).fetch("mass_threshold", DEFAULT_MASS_THRESHOLD)
+            engine_config.mass_threshold_for(LANGUAGE) || DEFAULT_MASS_THRESHOLD
           end
 
           def base_points

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -32,7 +32,7 @@ module CC
           end
 
           def mass_threshold
-            engine_config.fetch("config", {}).fetch("ruby", {}).fetch("mass_threshold", DEFAULT_MASS_THRESHOLD)
+            engine_config.mass_threshold_for(LANGUAGE) || DEFAULT_MASS_THRESHOLD
           end
 
           def base_points

--- a/lib/cc/engine/duplication.rb
+++ b/lib/cc/engine/duplication.rb
@@ -3,6 +3,7 @@ require 'cc/engine/analyzers/javascript/main'
 require 'cc/engine/analyzers/php/main'
 require 'cc/engine/analyzers/python/main'
 require 'cc/engine/analyzers/reporter'
+require 'cc/engine/analyzers/engine_config'
 require 'cc/engine/analyzers/sexp'
 require 'flay'
 require 'json'
@@ -10,7 +11,7 @@ require 'json'
 module CC
   module Engine
     class Duplication
-      DEFAULT_LANGUAGE = ['ruby'].freeze
+      DEFAULT_LANGUAGE = 'ruby'.freeze
       LANGUAGES = {
         "ruby"       => ::CC::Engine::Analyzers::Ruby::Main,
         "javascript" => ::CC::Engine::Analyzers::Javascript::Main,
@@ -20,7 +21,7 @@ module CC
 
       def initialize(directory:, engine_config:, io:)
         @directory = directory
-        @engine_config = engine_config || {}
+        @engine_config = CC::Engine::Analyzers::EngineConfig.new(engine_config || {})
         @io = io
       end
 
@@ -43,14 +44,12 @@ module CC
       end
 
       def languages
-        config_languages = engine_config.
-          fetch("config", {}).
-          fetch("languages", DEFAULT_LANGUAGE)
+        languages = engine_config.languages.keys
 
-        if config_languages.is_a?(Hash)
-          config_languages.keys
+        if languages.empty?
+          Array(DEFAULT_LANGUAGE)
         else
-          Array(config_languages)
+          languages
         end
       end
     end

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -1,0 +1,87 @@
+require "spec_helper"
+require "cc/engine/analyzers/engine_config"
+
+module CC::Engine::Analyzers
+  describe EngineConfig do
+    describe "#config" do
+      it "normalizes language config" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "EliXiR" => {
+                "mass_threshold" => 15
+              }
+            }
+          }
+        })
+
+        assert_equal engine_config.languages, { "elixir" =>  { "mass_threshold" => 15 } }
+      end
+
+      it "transforms language arrays into empty hashes" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => [
+              "EliXiR",
+              "RubY"
+            ]
+          }
+        })
+
+        assert_equal engine_config.languages, { "elixir" =>  {}, "ruby" => {} }
+      end
+
+      it "returns an empty hash if languages is invalid" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => "potato",
+          }
+        })
+
+        assert_equal engine_config.languages, {}
+      end
+    end
+
+    describe "#paths_for" do
+      it "returns paths values for given language" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "EliXiR" => {
+                "paths" => ["/", "/etc"],
+              }
+            }
+          }
+        })
+
+        assert_equal engine_config.paths_for("elixir"), ["/", "/etc"]
+      end
+    end
+
+    describe "mass_threshold_for" do
+      it "returns empty hash if language is not present" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "EliXiR" => {
+                "mass_threshold" => 13
+              }
+            }
+          }
+        })
+
+        assert_equal engine_config.mass_threshold_for("elixir"), 13
+      end
+    end
+
+    describe "exlude_paths" do
+      it "returns given exclude paths" do
+        engine_config = EngineConfig.new({
+          "exclude_paths" => ["/tmp"]
+        })
+
+        assert_equal engine_config.exclude_paths, ["/tmp"]
+      end
+    end
+  end
+end

--- a/spec/cc/engine/analyzers/file_list_spec.rb
+++ b/spec/cc/engine/analyzers/file_list_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "cc/engine/analyzers/file_list"
+require "cc/engine/analyzers/engine_config"
 
 module CC::Engine::Analyzers
   describe FileList do
@@ -15,7 +16,7 @@ module CC::Engine::Analyzers
       it "returns files from default_paths when language is missing paths" do
         file_list = ::CC::Engine::Analyzers::FileList.new(
           directory: @tmp_dir,
-          engine_config: {},
+          engine_config: EngineConfig.new({}),
           default_paths: ["**/*.js", "**/*.jsx"],
           language: "javascript",
         )
@@ -26,7 +27,7 @@ module CC::Engine::Analyzers
       it "returns files from engine config defined paths when present" do
         file_list = ::CC::Engine::Analyzers::FileList.new(
           directory: @tmp_dir,
-          engine_config: {
+          engine_config: EngineConfig.new({
             "config" => {
               "languages" => {
                 "elixir" => {
@@ -34,7 +35,7 @@ module CC::Engine::Analyzers
                 }
               }
             }
-          },
+          }),
           default_paths: ["**/*.js", "**/*.jsx"],
           language: "elixir",
         )
@@ -45,13 +46,13 @@ module CC::Engine::Analyzers
       it "returns files from default_paths when languages is an array" do
         file_list = ::CC::Engine::Analyzers::FileList.new(
           directory: @tmp_dir,
-          engine_config: {
+          engine_config: EngineConfig.new({
             "config" => {
               "languages" => [
                 "elixir"
               ],
             },
-          },
+          }),
           default_paths: ["**/*.js", "**/*.jsx"],
           language: "javascript",
         )

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'cc/engine/analyzers/javascript/main'
 require 'cc/engine/analyzers/reporter'
+require 'cc/engine/analyzers/engine_config'
 require 'flay'
 require 'tmpdir'
 
@@ -41,7 +42,15 @@ module CC::Engine::Analyzers::Javascript
       end
 
       def engine_conf
-        { 'config' => { 'javascript' => { 'mass_threshold' => 1 } } }
+        CC::Engine::Analyzers::EngineConfig.new({
+          'config' => {
+            'languages' => {
+                'javascript' => {
+                  'mass_threshold' => 1
+                }
+            }
+          }
+        })
       end
     end
   end

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 require 'cc/engine/analyzers/php/main'
 require 'cc/engine/analyzers/reporter'
+require 'cc/engine/analyzers/engine_config'
 require 'flay'
 require 'tmpdir'
 
@@ -54,7 +55,15 @@ module CC::Engine::Analyzers::Php
       end
 
       def engine_conf
-        { 'config' => { 'php' => { 'mass_threshold' => 5 } } }
+        CC::Engine::Analyzers::EngineConfig.new({
+          'config' => {
+            'languages' => {
+              'php' => {
+                'mass_threshold' => 5
+              }
+            }
+          }
+        })
       end
     end
   end

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -40,7 +40,15 @@ print("Hello", "python")
       end
 
       def engine_conf
-        { "config" => { "python" => { "mass_threshold" => 4 } } }
+        CC::Engine::Analyzers::EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "python" => {
+                "mass_threshold" => 4
+              }
+            }
+          }
+        })
       end
     end
   end

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -34,9 +34,10 @@ module CC::Engine::Analyzers::Ruby
         File.write(File.join(@code, path), content)
       end
 
-      def run_engine(config = nil)
+      def run_engine(config = {})
         io = StringIO.new
 
+        config = CC::Engine::Analyzers::EngineConfig.new(config)
         engine = ::CC::Engine::Analyzers::Ruby::Main.new(directory: @code, engine_config: config)
         reporter = ::CC::Engine::Analyzers::Reporter.new(@code, engine, io)
 


### PR DESCRIPTION
This adds the `EngineConfig` class for normalizing the passed in engine
config in a single place instead of using `fetch` all over the codebase
with hardcoded paths.

This also fixes the path `mass_threshold` looks for when fetching the
config.