### PR TITLE
Extract base analyzer class

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -1,0 +1,43 @@
+module CC
+  module Engine
+    module Analyzers
+      class Base
+        def initialize(engine_config:, directory:)
+          @engine_config = engine_config
+          @directory = directory
+        end
+
+        def run
+          files.map do |file|
+            process_file(file)
+          end
+        end
+
+        def mass_threshold
+          engine_config.mass_threshold_for(self.class::LANGUAGE) || self.class::DEFAULT_MASS_THRESHOLD
+        end
+
+        def base_points
+          self.class::BASE_POINTS
+        end
+
+        private
+
+        attr_reader :engine_config, :directory
+
+        def process_file(path)
+          raise NoMethodError.new("Subclass must implement `process_file`")
+        end
+
+        def files
+          ::CC::Engine::Analyzers::FileList.new(
+            directory: directory,
+            engine_config: engine_config,
+            default_paths: self.class::DEFAULT_PATHS,
+            language: self.class::LANGUAGE
+          ).files
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -1,3 +1,4 @@
+require "cc/engine/analyzers/analyzer_base"
 require "cc/engine/analyzers/javascript/parser"
 require "cc/engine/analyzers/javascript/node"
 require "cc/engine/analyzers/file_list"
@@ -8,37 +9,17 @@ module CC
   module Engine
     module Analyzers
       module Javascript
-        class Main
-          LANGUAGE = "javascript"
+        class Main < CC::Engine::Analyzers::Base
           DEFAULT_PATHS = [
             "**/*.js",
             "**/*.jsx"
           ]
+          LANGUAGE = "javascript"
           DEFAULT_MASS_THRESHOLD = 40
           BASE_POINTS = 3000
 
-          def initialize(engine_config:, directory:)
-            @engine_config = engine_config
-            @directory = directory
-          end
-
-          def run
-            files.map do |file|
-              process_file(file)
-            end
-          end
-
-          def mass_threshold
-            engine_config.mass_threshold_for(LANGUAGE) || DEFAULT_MASS_THRESHOLD
-          end
-
-          def base_points
-            BASE_POINTS
-          end
 
           private
-
-          attr_reader :engine_config, :directory
 
           def process_file(path)
             Node.new(js_parser.new(File.read(path), path).parse.syntax_tree, path).format
@@ -46,15 +27,6 @@ module CC
 
           def js_parser
             ::CC::Engine::Analyzers::Javascript::Parser
-          end
-
-          def files
-            ::CC::Engine::Analyzers::FileList.new(
-              directory: directory,
-              engine_config: engine_config,
-              default_paths: DEFAULT_PATHS,
-              language: LANGUAGE
-            ).files
           end
         end
       end

--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -1,4 +1,5 @@
 require 'cc/engine/analyzers/php/parser'
+require "cc/engine/analyzers/analyzer_base"
 require 'flay'
 require 'json'
 
@@ -6,7 +7,7 @@ module CC
   module Engine
     module Analyzers
       module Php
-        class Main
+        class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "php"
           DEFAULT_PATHS = [
             "**/*.php",
@@ -16,30 +17,7 @@ module CC
           DEFAULT_MASS_THRESHOLD = 10
           BASE_POINTS = 4_000
 
-          attr_reader :directory, :engine_config, :io
-
-          def initialize(directory:, engine_config:)
-            @directory = directory
-            @engine_config = engine_config || {}
-          end
-
-          def run
-            files.map do |file|
-              process_file(file)
-            end
-          end
-
-          def mass_threshold
-            engine_config.mass_threshold_for(LANGUAGE) || DEFAULT_MASS_THRESHOLD
-          end
-
-          def base_points
-            BASE_POINTS
-          end
-
           private
-
-          attr_reader :engine_config, :directory
 
           def process_file(path)
             code = File.read(path)
@@ -51,19 +29,8 @@ module CC
             end
           end
 
-          private
-
           def php_parser
             ::CC::Engine::Analyzers::Php::Parser
-          end
-
-          def files
-            ::CC::Engine::Analyzers::FileList.new(
-              directory: directory,
-              engine_config: engine_config,
-              default_paths: DEFAULT_PATHS,
-              language: LANGUAGE
-            ).files
           end
         end
       end

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -2,52 +2,23 @@ require "cc/engine/analyzers/python/parser"
 require "cc/engine/analyzers/python/node"
 require "cc/engine/analyzers/reporter"
 require "cc/engine/analyzers/file_list"
+require "cc/engine/analyzers/analyzer_base"
 require "flay"
 
 module CC
   module Engine
     module Analyzers
       module Python
-        class Main
+        class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "python"
           DEFAULT_PATHS = ["**/*.py"]
           DEFAULT_MASS_THRESHOLD = 40
           BASE_POINTS = 1000
 
-          def initialize(directory:, engine_config:)
-            @directory = directory
-            @engine_config = engine_config || {}
-          end
-
-          def run
-            files.map do |file|
-              process_file(file)
-            end
-          end
-
-          def mass_threshold
-            engine_config.mass_threshold_for(LANGUAGE) || DEFAULT_MASS_THRESHOLD
-          end
-
-          def base_points
-            BASE_POINTS
-          end
-
-          private
-
           attr_reader :directory, :engine_config
 
           def process_file(path)
             Node.new(::CC::Engine::Analyzers::Python::Parser.new(File.binread(path), path).parse.syntax_tree, path).format
-          end
-
-          def files
-            ::CC::Engine::Analyzers::FileList.new(
-              directory: directory,
-              engine_config: engine_config,
-              default_paths: DEFAULT_PATHS,
-              language: LANGUAGE
-            ).files
           end
         end
       end

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -1,12 +1,13 @@
 require "flay"
 require "json"
 require "cc/engine/analyzers/reporter"
+require "cc/engine/analyzers/analyzer_base"
 
 module CC
   module Engine
     module Analyzers
       module Ruby
-        class Main
+        class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "ruby"
           DEFAULT_PATHS = [
             "**/*.rb",
@@ -20,40 +21,12 @@ module CC
           BASE_POINTS = 10_000
           TIMEOUT = 10
 
-          def initialize(directory:, engine_config:)
-            @directory = directory
-            @engine_config = engine_config || {}
-          end
-
-          def run
-            files.map do |file|
-              process_file(file)
-            end
-          end
-
-          def mass_threshold
-            engine_config.mass_threshold_for(LANGUAGE) || DEFAULT_MASS_THRESHOLD
-          end
-
-          def base_points
-            BASE_POINTS
-          end
-
           private
 
           attr_reader :directory, :engine_config
 
           def process_file(file)
             RubyParser.new.process(File.binread(file), file, TIMEOUT)
-          end
-
-          def files
-            ::CC::Engine::Analyzers::FileList.new(
-              directory: directory,
-              engine_config: engine_config,
-              default_paths: DEFAULT_PATHS,
-              language: LANGUAGE
-            ).files
           end
         end
       end


### PR DESCRIPTION
This extracts common code from the analyzers into the `AnalyzerBase`
class.

The only requirements for an analyzer now are having the following
constants:

* `DEFAULT_PATHS` - default glob of files to analyze
* `LANGUAGE` - The analyzers language name as a string
* `DEFAULT_MASS_THRESHOLD` - Default mass we should tell Flay to use
* `BASE_POINTS` - Amount of points to multiply by mass

and the following method(s):

* `process_file(path)` - Returns s-expressions based on the file content
  of `path`.