### PR TITLE
Rescue and skip file when `process_file` fails

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -9,7 +9,12 @@ module CC
 
         def run
           files.map do |file|
-            process_file(file)
+            begin
+              process_file(file)
+            rescue => e
+              $stderr.puts "Skipping file #{file} due to exception"
+              $stderr.puts "(#{ex.class}) #{ex.message} #{ex.backtrace.join("\n")}"
+            end
           end
         end
 


### PR DESCRIPTION
This adds a begin/rescue/end block around `process_file(file)` calls so
when the analyze fails to analyze a file it is skipped instead of
crashing the entire engine.

Is there any type of logging we can do that would be valuable in the rescue block?