### PR TITLE
Allow empty language keys in config

### DIFF
--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -19,7 +19,11 @@ module CC
         end
 
         def paths_for(language)
-          fetch_language(language).fetch("paths", nil)
+          selected_language = fetch_language(language)
+
+          if selected_language.is_a? Hash
+            selected_language.fetch("paths", nil)
+          end
         end
 
         private

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -56,6 +56,18 @@ module CC::Engine::Analyzers
 
         assert_equal engine_config.paths_for("elixir"), ["/", "/etc"]
       end
+
+      it "returns nil if language is an empty key" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "EliXiR" => ""
+            }
+          }
+        })
+
+        assert_equal engine_config.paths_for("elixir"), nil
+      end
     end
 
     describe "mass_threshold_for" do


### PR DESCRIPTION
This allows `.codeclimate.yml` language keys to have empty values and
still be valid.

eg:

```
engines:
  duplication:
    enabled: true
    config:
      languages:
        javascript:
```