### PR TITLE
Always return hash for `fetch_language`

### DIFF
--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -19,11 +19,7 @@ module CC
         end
 
         def paths_for(language)
-          selected_language = fetch_language(language)
-
-          if selected_language.is_a? Hash
-            selected_language.fetch("paths", nil)
-          end
+          fetch_language(language).fetch("paths", nil)
         end
 
         private
@@ -31,9 +27,15 @@ module CC
         attr_reader :config
 
         def fetch_language(language)
-          config.
+          language = config.
             fetch("languages", {}).
             fetch(language, {})
+
+          if language.is_a? Hash
+            language
+          else
+            {}
+          end
         end
 
         def normalize(hash)

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -1,5 +1,6 @@
 require "spec_helper"
 require "cc/engine/analyzers/engine_config"
+require "cc/engine/analyzers/ruby/main"
 
 module CC::Engine::Analyzers
   describe EngineConfig do
@@ -83,6 +84,18 @@ module CC::Engine::Analyzers
         })
 
         assert_equal engine_config.mass_threshold_for("elixir"), 13
+      end
+
+      it "returns nil when language is empty" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "ruby" => "",
+            }
+          }
+        })
+
+        assert_equal engine_config.mass_threshold_for("ruby"), nil
       end
     end
 


### PR DESCRIPTION
Fetch language is used to grab the configuration for an individual
language and is expected to be a hash. This change makes
`fetch_language` return an empty hash if language isn't already a hash.