### PR TITLE
Convert configured mass threshold to integer

### DIFF
--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -15,7 +15,11 @@ module CC
         end
 
         def mass_threshold_for(language)
-          fetch_language(language).fetch("mass_threshold", nil)
+          threshold = fetch_language(language).fetch("mass_threshold", nil)
+
+          if threshold
+            threshold.to_i
+          end
         end
 
         def paths_for(language)

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -72,12 +72,12 @@ module CC::Engine::Analyzers
     end
 
     describe "mass_threshold_for" do
-      it "returns empty hash if language is not present" do
+      it "returns configured mass threshold as integer" do
         engine_config = EngineConfig.new({
           "config" => {
             "languages" => {
               "EliXiR" => {
-                "mass_threshold" => 13
+                "mass_threshold" => "13"
               }
             }
           }


### PR DESCRIPTION
Currently a configured mass threshold will be returned as a string when
flay expects an integer when it tries to compare mass to mass threshold.

This also renames the assertion since the previous title was incorrect.