### PR TITLE
Fix exclude paths

### DIFF
--- a/lib/cc/engine/analyzers/file_list.rb
+++ b/lib/cc/engine/analyzers/file_list.rb
@@ -34,7 +34,7 @@ module CC
         end
 
         def excluded_files
-          excluded_paths.map { |path| Dir.glob("#{directory}/path") }.flatten
+          @_excluded_files ||= excluded_paths.map { |path| Dir.glob("#{directory}/#{path}") }.flatten
         end
 
         def excluded_paths

--- a/spec/cc/engine/analyzers/file_list_spec.rb
+++ b/spec/cc/engine/analyzers/file_list_spec.rb
@@ -59,6 +59,24 @@ module CC::Engine::Analyzers
 
         assert_equal file_list.files, ["#{@tmp_dir}/foo.js", "#{@tmp_dir}/foo.jsx"]
       end
+
+      it "excludes files from paths in exclude_files" do
+        file_list = ::CC::Engine::Analyzers::FileList.new(
+          directory: @tmp_dir,
+          engine_config: EngineConfig.new({
+            "exclude_paths" => ["**/*.js"],
+            "config" => {
+              "languages" => [
+                "elixir"
+              ],
+            },
+          }),
+          default_paths: ["**/*.js", "**/*.jsx"],
+          language: "javascript",
+        )
+
+        assert_equal file_list.files, ["#{@tmp_dir}/foo.jsx"]
+      end
     end
   end
 end


### PR DESCRIPTION
The line that globs exclude paths had the word `path` hardcoded and
was never actually excluding the paths properly.

This adds a spec and interpolates the path properly.

I'm surprised this made it through as is throughout the refactorings.