### PR TITLE
Warn on stderr and raise an exception if no languages are enabled

### DIFF
--- a/lib/cc/engine/duplication.rb
+++ b/lib/cc/engine/duplication.rb
@@ -11,7 +11,8 @@ require 'json'
 module CC
   module Engine
     class Duplication
-      DEFAULT_LANGUAGE = 'ruby'.freeze
+      EmptyLanguagesError = Class.new(StandardError)
+
       LANGUAGES = {
         "ruby"       => ::CC::Engine::Analyzers::Ruby::Main,
         "javascript" => ::CC::Engine::Analyzers::Javascript::Main,
@@ -47,7 +48,9 @@ module CC
         languages = engine_config.languages.keys
 
         if languages.empty?
-          Array(DEFAULT_LANGUAGE)
+          message = "Config Error: Unable to run the duplication engine without any languages enabled."
+          $stderr.puts message
+          raise EmptyLanguagesError, message
         else
           languages
         end

--- a/spec/cc/engine/duplication_spec.rb
+++ b/spec/cc/engine/duplication_spec.rb
@@ -1,0 +1,16 @@
+require "spec_helper"
+require "cc/engine/duplication"
+
+module CC::Engine
+  describe "#languages" do
+    it "Warns to stderr and raises an exception when no languages are enabled" do
+      engine = Duplication.new(directory: "/code", engine_config: {}, io: StringIO.new)
+
+      _, stderr = capture_io do
+        assert_raises(Duplication::EmptyLanguagesError) { engine.run }
+      end
+
+      stderr.must_match("Config Error: Unable to run the duplication engine without any languages enabled.")
+    end
+  end
+end


### PR DESCRIPTION
Instead of picking a default language, the change in this PR will warn on stderr and raise an exception when no languages are enabled for duplication analysis.