### PR TITLE
Ensure value is always defined before access

### DIFF
--- a/lib/cc/engine/analyzers/javascript/parser.js
+++ b/lib/cc/engine/analyzers/javascript/parser.js
@@ -32,17 +32,19 @@ var format = function(node) {
     if (node.hasOwnProperty(prop) && !prop.startsWith("_") && toScrub.indexOf(prop) === -1) {
       var value = node[prop];
 
-      if (value && value.constructor === Array) {
-        result[prop] = value.map(function(p) {
-          return format(p)
-        });
-      } else if (prop === "loc") {
-        result["start"] = value.start.line;
-        result["end"] = value.end.line;
-      } else if (value && typeof(value) === "object") {
-        result[prop] = format(value);
-      } else if (value) {
-        result[prop] = node[prop];
+      if (value) {
+        if (value.constructor === Array) {
+          result[prop] = value.map(function(p) {
+            return format(p)
+          });
+        } else if (prop === "loc") {
+          result["start"] = value.start.line;
+          result["end"] = value.end.line;
+        } else if (typeof(value) === "object") {
+          result[prop] = format(value);
+        } else  {
+          result[prop] = node[prop];
+        }
       }
     }
   }


### PR DESCRIPTION
In parsing some JSX from relax/relax, we noticed the parser was choking
on trying to access attributes of the loc attribute of a given node. It
looks like we were checking for the presence of value in every other
branch so this change hoists that check up around the processing.