### PR TITLE
Raise the default Ruby mass threshold to 18

### DIFF
--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -17,7 +17,7 @@ module CC
             "**/*.gemspec"
 
           ]
-          DEFAULT_MASS_THRESHOLD = 10
+          DEFAULT_MASS_THRESHOLD = 18
           BASE_POINTS = 10_000
           TIMEOUT = 10
 


### PR DESCRIPTION
Currently the mass threshold is too sensitive and allows blocks of code
that shouldn't be compared through. This increases the threshold to 18
to help the engine feel less sensitive.