### PR TITLE
chdir into code directory and use relative paths

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -2,9 +2,8 @@ module CC
   module Engine
     module Analyzers
       class Base
-        def initialize(engine_config:, directory:)
+        def initialize(engine_config:)
           @engine_config = engine_config
-          @directory = directory
         end
 
         def run
@@ -28,7 +27,7 @@ module CC
 
         private
 
-        attr_reader :engine_config, :directory
+        attr_reader :engine_config
 
         def process_file(path)
           raise NoMethodError.new("Subclass must implement `process_file`")
@@ -36,7 +35,6 @@ module CC
 
         def files
           ::CC::Engine::Analyzers::FileList.new(
-            directory: directory,
             engine_config: engine_config,
             default_paths: self.class::DEFAULT_PATHS,
             language: self.class::LANGUAGE

--- a/lib/cc/engine/analyzers/file_list.rb
+++ b/lib/cc/engine/analyzers/file_list.rb
@@ -2,8 +2,7 @@ module CC
   module Engine
     module Analyzers
       class FileList
-        def initialize(directory:, engine_config:, default_paths:, language:)
-          @directory = directory
+        def initialize(engine_config:, default_paths:, language:)
           @engine_config = engine_config
           @default_paths = default_paths
           @language = language
@@ -15,11 +14,11 @@ module CC
 
         private
 
-        attr_reader :directory, :engine_config, :default_paths, :language
+        attr_reader :engine_config, :default_paths, :language
 
         def matching_files
           paths.map do |glob|
-            Dir.glob("#{directory}/#{glob}").reject do |f|
+            Dir.glob("./#{glob}").reject do |f|
               File.directory?(f)
             end
           end.flatten
@@ -34,7 +33,7 @@ module CC
         end
 
         def excluded_files
-          @_excluded_files ||= excluded_paths.map { |path| Dir.glob("#{directory}/#{path}") }.flatten
+          @_excluded_files ||= excluded_paths.map { |path| Dir.glob("./#{path}") }.flatten
         end
 
         def excluded_paths

--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -20,7 +20,7 @@ module CC
           private
 
           def process_file(path)
-            code = File.read(path)
+            code = File.binread(path)
             parser = php_parser.new(code, path).parse
             syntax_tree = parser.syntax_tree
 

--- a/lib/cc/engine/analyzers/php/parser.rb
+++ b/lib/cc/engine/analyzers/php/parser.rb
@@ -30,7 +30,10 @@ module CC
         private
 
           def parser_path
-            "vendor/php-parser/parser.php"
+            relative_path = "../../../../../vendor/php-parser/parser.php"
+            File.expand_path(
+              File.join(File.dirname(__FILE__), relative_path)
+            )
           end
         end
 

--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -5,8 +5,7 @@ module CC
     module Analyzers
       class Reporter
         TIMEOUT = 10
-        def initialize(directory, language_strategy, io)
-          @directory = directory
+        def initialize(language_strategy, io)
           @language_strategy = language_strategy
           @io = io
         end
@@ -38,7 +37,7 @@ module CC
           @flay ||= Flay.new(flay_options)
         end
 
-        attr_reader :language_strategy, :directory, :io
+        attr_reader :language_strategy, :io
 
         def mass_threshold
           @mass_threshold ||= language_strategy.mass_threshold
@@ -46,7 +45,7 @@ module CC
 
         def new_violation(issue)
           hashes = flay.hashes[issue.structural_hash]
-          Violation.new(language_strategy.base_points, issue, hashes, directory).format
+          Violation.new(language_strategy.base_points, issue, hashes).format
         end
 
         def flay_options

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -4,11 +4,10 @@ module CC
       class Violation
         attr_reader :issue
 
-        def initialize(base_points, issue, hashes, directory)
+        def initialize(base_points, issue, hashes)
           @base_points = base_points
           @issue = issue
           @hashes = hashes
-          @directory = directory
         end
 
         def format
@@ -26,7 +25,7 @@ module CC
 
         private
 
-        attr_reader :base_points, :hashes, :directory
+        attr_reader :base_points, :hashes
 
         def current_sexp
           @location ||= hashes.first
@@ -59,9 +58,8 @@ module CC
         end
 
         def format_sexp(sexp)
-          relative_path = sexp.file.gsub(/^#{directory}\//, "")
           {
-            "path": relative_path,
+            "path": sexp.file.gsub(%r(^./), ""),
             "lines": {
               "begin": sexp.line,
               "end": sexp.end_line || sexp_max_line(sexp, sexp.line)
@@ -80,8 +78,14 @@ module CC
         end
 
         def content_body
-          read_up = File.read('config/contents/duplicated_code.md')
-          { "body": read_up }
+          @_content_body ||= { "body": File.read(read_up_path) }
+        end
+
+        def read_up_path
+          relative_path = "../../../../config/contents/duplicated_code.md"
+          File.expand_path(
+            File.join(File.dirname(__FILE__), relative_path)
+          )
         end
 
         def description

--- a/lib/cc/engine/duplication.rb
+++ b/lib/cc/engine/duplication.rb
@@ -21,22 +21,22 @@ module CC
       }.freeze
 
       def initialize(directory:, engine_config:, io:)
-        @directory = directory
+        Dir.chdir(directory)
         @engine_config = CC::Engine::Analyzers::EngineConfig.new(engine_config || {})
         @io = io
       end
 
       def run
         languages_to_analyze.each do |language|
-          engine = LANGUAGES[language].new(directory: directory, engine_config: engine_config)
-          reporter = CC::Engine::Analyzers::Reporter.new(directory, engine, io)
+          engine = LANGUAGES[language].new(engine_config: engine_config)
+          reporter = CC::Engine::Analyzers::Reporter.new(engine, io)
           reporter.run
         end
       end
 
       private
 
-      attr_reader :directory, :engine_config, :io
+      attr_reader :engine_config, :io
 
       def languages_to_analyze
         languages.select do |language|

--- a/spec/cc/engine/analyzers/file_list_spec.rb
+++ b/spec/cc/engine/analyzers/file_list_spec.rb
@@ -6,27 +6,30 @@ module CC::Engine::Analyzers
   describe FileList do
     before do
       @tmp_dir = Dir.mktmpdir
+      Dir.chdir(@tmp_dir)
 
       File.write(File.join(@tmp_dir, "foo.js"), "")
       File.write(File.join(@tmp_dir, "foo.jsx"), "")
       File.write(File.join(@tmp_dir, "foo.ex"), "")
     end
 
+    after do
+      FileUtils.rm_rf(@tmp_dir)
+    end
+
     describe "#files" do
       it "returns files from default_paths when language is missing paths" do
         file_list = ::CC::Engine::Analyzers::FileList.new(
-          directory: @tmp_dir,
           engine_config: EngineConfig.new({}),
           default_paths: ["**/*.js", "**/*.jsx"],
           language: "javascript",
         )
 
-        assert_equal file_list.files, ["#{@tmp_dir}/foo.js", "#{@tmp_dir}/foo.jsx"]
+        assert_equal file_list.files, ["./foo.js", "./foo.jsx"]
       end
 
       it "returns files from engine config defined paths when present" do
         file_list = ::CC::Engine::Analyzers::FileList.new(
-          directory: @tmp_dir,
           engine_config: EngineConfig.new({
             "config" => {
               "languages" => {
@@ -40,12 +43,11 @@ module CC::Engine::Analyzers
           language: "elixir",
         )
 
-        assert_equal file_list.files, ["#{@tmp_dir}/foo.ex"]
+        assert_equal file_list.files, ["./foo.ex"]
       end
 
       it "returns files from default_paths when languages is an array" do
         file_list = ::CC::Engine::Analyzers::FileList.new(
-          directory: @tmp_dir,
           engine_config: EngineConfig.new({
             "config" => {
               "languages" => [
@@ -57,12 +59,11 @@ module CC::Engine::Analyzers
           language: "javascript",
         )
 
-        assert_equal file_list.files, ["#{@tmp_dir}/foo.js", "#{@tmp_dir}/foo.jsx"]
+        assert_equal file_list.files, ["./foo.js", "./foo.jsx"]
       end
 
       it "excludes files from paths in exclude_files" do
         file_list = ::CC::Engine::Analyzers::FileList.new(
-          directory: @tmp_dir,
           engine_config: EngineConfig.new({
             "exclude_paths" => ["**/*.js"],
             "config" => {
@@ -75,7 +76,7 @@ module CC::Engine::Analyzers
           language: "javascript",
         )
 
-        assert_equal file_list.files, ["#{@tmp_dir}/foo.jsx"]
+        assert_equal file_list.files, ["./foo.jsx"]
       end
     end
   end

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -2,12 +2,20 @@ require 'spec_helper'
 require 'cc/engine/analyzers/javascript/main'
 require 'cc/engine/analyzers/reporter'
 require 'cc/engine/analyzers/engine_config'
+require 'cc/engine/analyzers/file_list'
 require 'flay'
 require 'tmpdir'
 
 module CC::Engine::Analyzers::Javascript
   describe Main do
-    before { @code = Dir.mktmpdir }
+    before do
+      @code = Dir.mktmpdir
+      Dir.chdir(@code)
+    end
+
+    after do
+      FileUtils.rm_rf(@code)
+    end
 
     describe "#run" do
       it "prints an issue" do
@@ -28,8 +36,8 @@ module CC::Engine::Analyzers::Javascript
       def run_engine(config = nil)
         io = StringIO.new
 
-        engine = ::CC::Engine::Analyzers::Javascript::Main.new(directory: @code, engine_config: config)
-        reporter = ::CC::Engine::Analyzers::Reporter.new(@code, engine, io)
+        engine = ::CC::Engine::Analyzers::Javascript::Main.new(engine_config: config)
+        reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
 
         reporter.run
 

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -2,12 +2,20 @@ require 'spec_helper'
 require 'cc/engine/analyzers/php/main'
 require 'cc/engine/analyzers/reporter'
 require 'cc/engine/analyzers/engine_config'
+require 'cc/engine/analyzers/file_list'
 require 'flay'
 require 'tmpdir'
 
 module CC::Engine::Analyzers::Php
   describe Main do
-    before { @code = Dir.mktmpdir }
+    before do
+      @code = Dir.mktmpdir
+      Dir.chdir(@code)
+    end
+
+    after do
+      FileUtils.rm_rf(@code)
+    end
 
     describe "#run" do
       it "prints an issue" do
@@ -41,8 +49,8 @@ module CC::Engine::Analyzers::Php
       def run_engine(config = nil)
         io = StringIO.new
 
-        engine = ::CC::Engine::Analyzers::Php::Main.new(directory: @code, engine_config: config)
-        reporter = ::CC::Engine::Analyzers::Reporter.new(@code, engine, io)
+        engine = ::CC::Engine::Analyzers::Php::Main.new(engine_config: config)
+        reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
 
         reporter.run
 

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -1,11 +1,20 @@
 require "spec_helper"
 require "cc/engine/analyzers/python/main"
+require 'cc/engine/analyzers/engine_config'
+require 'cc/engine/analyzers/file_list'
 require "flay"
 require "tmpdir"
 
 module CC::Engine::Analyzers::Python
   describe Main do
-    before { @code = Dir.mktmpdir }
+    before do
+      @code = Dir.mktmpdir
+      Dir.chdir(@code)
+    end
+
+    after do
+      FileUtils.rm_rf(@code)
+    end
 
     describe "#run" do
       it "prints an issue" do
@@ -26,8 +35,8 @@ print("Hello", "python")
       def run_engine(config = nil)
         io = StringIO.new
 
-        engine = ::CC::Engine::Analyzers::Python::Main.new(directory: @code, engine_config: config)
-        reporter = ::CC::Engine::Analyzers::Reporter.new(@code, engine, io)
+        engine = ::CC::Engine::Analyzers::Python::Main.new(engine_config: config)
+        reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
 
         reporter.run
 

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -1,11 +1,20 @@
 require 'spec_helper'
 require 'cc/engine/analyzers/ruby/main'
+require 'cc/engine/analyzers/engine_config'
+require 'cc/engine/analyzers/file_list'
 require 'flay'
 require 'tmpdir'
 
 module CC::Engine::Analyzers::Ruby
   describe Main do
-    before { @code = Dir.mktmpdir }
+    before do
+      @code = Dir.mktmpdir
+      Dir.chdir(@code)
+    end
+
+    after do
+      FileUtils.rm_rf(@code)
+    end
 
     describe "#run" do
       it "prints an issue" do
@@ -50,8 +59,8 @@ module CC::Engine::Analyzers::Ruby
         io = StringIO.new
 
         config = CC::Engine::Analyzers::EngineConfig.new(config)
-        engine = ::CC::Engine::Analyzers::Ruby::Main.new(directory: @code, engine_config: config)
-        reporter = ::CC::Engine::Analyzers::Reporter.new(@code, engine, io)
+        engine = ::CC::Engine::Analyzers::Ruby::Main.new(engine_config: config)
+        reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
 
         reporter.run
 

--- a/spec/cc/engine/duplication_spec.rb
+++ b/spec/cc/engine/duplication_spec.rb
@@ -4,13 +4,17 @@ require "cc/engine/duplication"
 module CC::Engine
   describe "#languages" do
     it "Warns to stderr and raises an exception when no languages are enabled" do
-      engine = Duplication.new(directory: "/code", engine_config: {}, io: StringIO.new)
+      directory = Dir.mktmpdir
+
+      engine = Duplication.new(directory: directory, engine_config: {}, io: StringIO.new)
 
       _, stderr = capture_io do
         assert_raises(Duplication::EmptyLanguagesError) { engine.run }
       end
 
       stderr.must_match("Config Error: Unable to run the duplication engine without any languages enabled.")
+
+      FileUtils.rm_rf(directory)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,5 +5,12 @@ require 'minitest/unit'
 Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new
 
 def read_up
-  File.read('config/contents/duplicated_code.md')
+  File.read(read_up_path)
+end
+
+def read_up_path
+  relative_path = "../config/contents/duplicated_code.md"
+  File.expand_path(
+    File.join(File.dirname(__FILE__), relative_path)
+  )
 end


### PR DESCRIPTION
Currently the engine uses absolute paths to `/code` when working with
files to analyze.

Now instead of using absolute paths to the files to analyze we `chdir`
to the given code directory and read files relative to the current path.
This will make the migration to use `include_paths` from `exclude_paths`
easier.