### PR TITLE
Use git to fetch composer dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,14 +8,14 @@ COPY Gemfile.lock /usr/src/app/
 COPY vendor/php-parser/composer.json /usr/src/app/vendor/php-parser/
 COPY vendor/php-parser/composer.lock /usr/src/app/vendor/php-parser/
 
-RUN apk --update add python nodejs php-cli php-json php-phar php-openssl php-xml curl\
+RUN apk --update add git python nodejs php-cli php-json php-phar php-openssl php-xml curl\
     ruby ruby-io-console ruby-dev ruby-bundler build-base && \
     bundle install -j 4 && \
     apk del build-base && rm -fr /usr/share/ri && \
     curl -sS https://getcomposer.org/installer | php
 
 RUN mv composer.phar /usr/local/bin/composer
-RUN cd /usr/src/app/vendor/php-parser/ && composer install
+RUN cd /usr/src/app/vendor/php-parser/ && composer install --prefer-source --no-interaction
 
 RUN adduser -u 9000 -D app
 


### PR DESCRIPTION
Composer occasionally fails the build on CircleCI because it is hitting
Github API rate limits.

According to https://circleci.com/docs/composer-api-rate-limit we can
use the `--prefer-source` and `--no-interaction` flags when calling
`composer install` to get around this.