### PR TITLE
Migrate from Minitest to RSpec

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,1 @@
+--require spec_helper

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,5 @@ gem 'json'
 
 group :test do
   gem 'rake'
-  gem 'minitest'
-  gem 'minitest-reporters'
+  gem 'rspec'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,27 +1,32 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    ansi (1.5.0)
-    builder (3.2.2)
     coderay (1.1.0)
+    diff-lcs (1.2.5)
     flay (2.6.1)
       ruby_parser (~> 3.0)
       sexp_processor (~> 4.0)
     json (1.8.3)
     method_source (0.8.2)
-    minitest (5.8.0)
-    minitest-reporters (1.0.20)
-      ansi
-      builder
-      minitest (>= 5.0)
-      ruby-progressbar
     posix-spawn (0.3.11)
     pry (0.10.1)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rake (10.4.2)
-    ruby-progressbar (1.7.5)
+    rspec (3.3.0)
+      rspec-core (~> 3.3.0)
+      rspec-expectations (~> 3.3.0)
+      rspec-mocks (~> 3.3.0)
+    rspec-core (3.3.2)
+      rspec-support (~> 3.3.0)
+    rspec-expectations (3.3.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-mocks (3.3.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.3.0)
+    rspec-support (3.3.0)
     ruby_parser (3.7.1)
       sexp_processor (~> 4.1)
     sexp_processor (4.6.0)
@@ -33,9 +38,11 @@ PLATFORMS
 DEPENDENCIES
   flay
   json
-  minitest
-  minitest-reporters
   posix-spawn
   pry
   rake
+  rspec
   sexp_processor
+
+BUNDLED WITH
+   1.10.6

--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,7 @@
-require 'rake/testtask'
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
 
-Rake::TestTask.new do |t|
-  t.test_files = Dir.glob('spec/**/*_spec.rb')
-  t.libs = ["lib", "spec"]
+  task :default => :spec
+rescue LoadError
 end
-
-task(default: :test)

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -2,111 +2,114 @@ require "spec_helper"
 require "cc/engine/analyzers/engine_config"
 require "cc/engine/analyzers/ruby/main"
 
-module CC::Engine::Analyzers
-  describe EngineConfig do
-    describe "#config" do
-      it "normalizes language config" do
-        engine_config = EngineConfig.new({
-          "config" => {
-            "languages" => {
-              "EliXiR" => {
-                "mass_threshold" => 15
-              }
+RSpec.describe CC::Engine::Analyzers::EngineConfig  do
+  describe "#config" do
+    it "normalizes language config" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => {
+            "EliXiR" => {
+              "mass_threshold" => 15
             }
           }
-        })
+        }
+      })
 
-        assert_equal engine_config.languages, { "elixir" =>  { "mass_threshold" => 15 } }
-      end
-
-      it "transforms language arrays into empty hashes" do
-        engine_config = EngineConfig.new({
-          "config" => {
-            "languages" => [
-              "EliXiR",
-              "RubY"
-            ]
-          }
-        })
-
-        assert_equal engine_config.languages, { "elixir" =>  {}, "ruby" => {} }
-      end
-
-      it "returns an empty hash if languages is invalid" do
-        engine_config = EngineConfig.new({
-          "config" => {
-            "languages" => "potato",
-          }
-        })
-
-        assert_equal engine_config.languages, {}
-      end
+      expect(engine_config.languages,).to eq({
+        "elixir" =>  { "mass_threshold" => 15 }
+      })
     end
 
-    describe "#paths_for" do
-      it "returns paths values for given language" do
-        engine_config = EngineConfig.new({
-          "config" => {
-            "languages" => {
-              "EliXiR" => {
-                "paths" => ["/", "/etc"],
-              }
-            }
-          }
-        })
+    it "transforms language arrays into empty hashes" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => [
+            "EliXiR",
+            "RubY"
+          ]
+        }
+      })
 
-        assert_equal engine_config.paths_for("elixir"), ["/", "/etc"]
-      end
-
-      it "returns nil if language is an empty key" do
-        engine_config = EngineConfig.new({
-          "config" => {
-            "languages" => {
-              "EliXiR" => ""
-            }
-          }
-        })
-
-        assert_equal engine_config.paths_for("elixir"), nil
-      end
+      expect(engine_config.languages).to eq({
+        "elixir" =>  {},
+        "ruby" => {}
+      })
     end
 
-    describe "mass_threshold_for" do
-      it "returns configured mass threshold as integer" do
-        engine_config = EngineConfig.new({
-          "config" => {
-            "languages" => {
-              "EliXiR" => {
-                "mass_threshold" => "13"
-              }
+    it "returns an empty hash if languages is invalid" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => "potato",
+        }
+      })
+
+      expect(engine_config.languages).to eq({})
+    end
+  end
+
+  describe "#paths_for" do
+    it "returns paths values for given language" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => {
+            "EliXiR" => {
+              "paths" => ["/", "/etc"],
             }
           }
-        })
+        }
+      })
 
-        assert_equal engine_config.mass_threshold_for("elixir"), 13
-      end
-
-      it "returns nil when language is empty" do
-        engine_config = EngineConfig.new({
-          "config" => {
-            "languages" => {
-              "ruby" => "",
-            }
-          }
-        })
-
-        assert_equal engine_config.mass_threshold_for("ruby"), nil
-      end
+      expect(engine_config.paths_for("elixir")).to eq(["/", "/etc"])
     end
 
-    describe "exlude_paths" do
-      it "returns given exclude paths" do
-        engine_config = EngineConfig.new({
-          "exclude_paths" => ["/tmp"]
-        })
+    it "returns nil if language is an empty key" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => {
+            "EliXiR" => ""
+          }
+        }
+      })
 
-        assert_equal engine_config.exclude_paths, ["/tmp"]
-      end
+      expect(engine_config.paths_for("elixir")).to be_nil
+    end
+  end
+
+  describe "mass_threshold_for" do
+    it "returns configured mass threshold as integer" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => {
+            "EliXiR" => {
+              "mass_threshold" => "13"
+            }
+          }
+        }
+      })
+
+      expect(engine_config.mass_threshold_for("elixir")).to eq(13)
+    end
+
+    it "returns nil when language is empty" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => {
+            "ruby" => "",
+          }
+        }
+      })
+
+      expect(engine_config.mass_threshold_for("ruby")).to be_nil
+    end
+  end
+
+  describe "exlude_paths" do
+    it "returns given exclude paths" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "exclude_paths" => ["/tmp"]
+      })
+
+      expect(engine_config.exclude_paths).to eq(["/tmp"])
     end
   end
 end

--- a/spec/cc/engine/analyzers/file_list_spec.rb
+++ b/spec/cc/engine/analyzers/file_list_spec.rb
@@ -2,82 +2,81 @@ require "spec_helper"
 require "cc/engine/analyzers/file_list"
 require "cc/engine/analyzers/engine_config"
 
-module CC::Engine::Analyzers
-  describe FileList do
-    before do
-      @tmp_dir = Dir.mktmpdir
-      Dir.chdir(@tmp_dir)
+RSpec.describe CC::Engine::Analyzers::FileList do
+  around do |example|
+    Dir.mktmpdir do |directory|
+      @tmp_dir = directory
 
-      File.write(File.join(@tmp_dir, "foo.js"), "")
-      File.write(File.join(@tmp_dir, "foo.jsx"), "")
-      File.write(File.join(@tmp_dir, "foo.ex"), "")
-    end
+      Dir.chdir(@tmp_dir) do
+        File.write(File.join(@tmp_dir, "foo.js"), "")
+        File.write(File.join(@tmp_dir, "foo.jsx"), "")
+        File.write(File.join(@tmp_dir, "foo.ex"), "")
 
-    after do
-      FileUtils.rm_rf(@tmp_dir)
-    end
-
-    describe "#files" do
-      it "returns files from default_paths when language is missing paths" do
-        file_list = ::CC::Engine::Analyzers::FileList.new(
-          engine_config: EngineConfig.new({}),
-          default_paths: ["**/*.js", "**/*.jsx"],
-          language: "javascript",
-        )
-
-        assert_equal file_list.files, ["./foo.js", "./foo.jsx"]
+        example.run
       end
+    end
+  end
 
-      it "returns files from engine config defined paths when present" do
-        file_list = ::CC::Engine::Analyzers::FileList.new(
-          engine_config: EngineConfig.new({
-            "config" => {
-              "languages" => {
-                "elixir" => {
-                  "paths" => ["**/*.ex"]
-                }
+  describe "#files" do
+    it "returns files from default_paths when language is missing paths" do
+      file_list = ::CC::Engine::Analyzers::FileList.new(
+        engine_config: CC::Engine::Analyzers::EngineConfig.new({}),
+        default_paths: ["**/*.js", "**/*.jsx"],
+        language: "javascript",
+      )
+
+      expect(file_list.files).to eq(["./foo.js", "./foo.jsx"])
+    end
+
+    it "returns files from engine config defined paths when present" do
+      file_list = ::CC::Engine::Analyzers::FileList.new(
+        engine_config: CC::Engine::Analyzers::EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "elixir" => {
+                "paths" => ["**/*.ex"]
               }
             }
-          }),
-          default_paths: ["**/*.js", "**/*.jsx"],
-          language: "elixir",
-        )
+          }
+        }),
+        default_paths: ["**/*.js", "**/*.jsx"],
+        language: "elixir",
+      )
 
-        assert_equal file_list.files, ["./foo.ex"]
-      end
+      expect(file_list.files).to eq(["./foo.ex"])
+    end
 
-      it "returns files from default_paths when languages is an array" do
-        file_list = ::CC::Engine::Analyzers::FileList.new(
-          engine_config: EngineConfig.new({
-            "config" => {
-              "languages" => [
-                "elixir"
-              ],
-            },
-          }),
-          default_paths: ["**/*.js", "**/*.jsx"],
-          language: "javascript",
-        )
+    it "returns files from default_paths when languages is an array" do
+      file_list = ::CC::Engine::Analyzers::FileList.new(
+        engine_config: CC::Engine::Analyzers::EngineConfig.new({
+          "config" => {
+            "languages" => [
+              "elixir"
+            ],
+          },
+        }),
+        default_paths: ["**/*.js", "**/*.jsx"],
+        language: "javascript",
+      )
 
-        assert_equal file_list.files, ["./foo.js", "./foo.jsx"]
-      end
+      expect(file_list.files).to eq(["./foo.js", "./foo.jsx"])
+    end
 
-      it "excludes files from paths in exclude_files" do
-        file_list = ::CC::Engine::Analyzers::FileList.new(
-          engine_config: EngineConfig.new({
-            "exclude_paths" => ["**/*.js"],
-            "config" => {
-              "languages" => [
-                "elixir"
-              ],
-            },
-          }),
-          default_paths: ["**/*.js", "**/*.jsx"],
-          language: "javascript",
-        )
+    it "excludes files from paths in exclude_files" do
+      file_list = ::CC::Engine::Analyzers::FileList.new(
+        engine_config: CC::Engine::Analyzers::EngineConfig.new({
+          "exclude_paths" => ["**/*.js"],
+          "config" => {
+            "languages" => [
+              "elixir"
+            ],
+          },
+        }),
+        default_paths: ["**/*.js", "**/*.jsx"],
+        language: "javascript",
+      )
 
-        assert_equal file_list.files, ["./foo.jsx"]
-      end
+      expect(file_list.files).to eq(["./foo.jsx"])
     end
   end
 end

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'cc/engine/analyzers/javascript/main'
 require 'cc/engine/analyzers/reporter'
 require 'cc/engine/analyzers/engine_config'
@@ -6,60 +5,59 @@ require 'cc/engine/analyzers/file_list'
 require 'flay'
 require 'tmpdir'
 
-module CC::Engine::Analyzers::Javascript
-  describe Main do
-    before do
-      @code = Dir.mktmpdir
-      Dir.chdir(@code)
+RSpec.describe CC::Engine::Analyzers::Javascript::Main do
+  around do |example|
+    Dir.mktmpdir do |directory|
+      @code = directory
+
+      Dir.chdir(directory) do
+        example.run
+      end
     end
+  end
 
-    after do
-      FileUtils.rm_rf(@code)
+  describe "#run" do
+    it "prints an issue" do
+
+      create_source_file("foo.js", <<-EOJS)
+          console.log("hello JS!");
+          console.log("hello JS!");
+          console.log("hello JS!");
+      EOJS
+
+      expect(run_engine(engine_conf)).to eq(printed_issue)
     end
+  end
 
-    describe "#run" do
-      it "prints an issue" do
+  def create_source_file(path, content)
+    File.write(File.join(@code, path), content)
+  end
 
-        create_source_file("foo.js", <<-EOJS)
-          console.log("hello JS!");
-          console.log("hello JS!");
-          console.log("hello JS!");
-        EOJS
+  def run_engine(config = nil)
+    io = StringIO.new
 
-        assert_equal run_engine(engine_conf), printed_issue
-      end
+    engine = ::CC::Engine::Analyzers::Javascript::Main.new(engine_config: config)
+    reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
 
-      def create_source_file(path, content)
-        File.write(File.join(@code, path), content)
-      end
+    reporter.run
 
-      def run_engine(config = nil)
-        io = StringIO.new
+    io.string
+  end
 
-        engine = ::CC::Engine::Analyzers::Javascript::Main.new(engine_config: config)
-        reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
+  def printed_issue
+    issue = {"type":"issue","check_name":"Identical code","description":"Similar code found in 2 other locations","categories":["Duplication"],"location":{"path":"foo.js","lines":{"begin":1,"end":1}},"remediation_points":378000, "other_locations":[{"path":"foo.js","lines":{"begin":2,"end":2}},{"path":"foo.js","lines":{"begin":3,"end":3}}], "content":{"body": read_up}}
+    issue.to_json + "\0\n"
+  end
 
-        reporter.run
-
-        io.string
-      end
-
-      def printed_issue
-        issue = {"type":"issue","check_name":"Identical code","description":"Similar code found in 2 other locations","categories":["Duplication"],"location":{"path":"foo.js","lines":{"begin":1,"end":1}},"remediation_points":378000, "other_locations":[{"path":"foo.js","lines":{"begin":2,"end":2}},{"path":"foo.js","lines":{"begin":3,"end":3}}], "content":{"body": read_up}}
-        issue.to_json + "\0\n"
-      end
-
-      def engine_conf
-        CC::Engine::Analyzers::EngineConfig.new({
-          'config' => {
-            'languages' => {
-                'javascript' => {
-                  'mass_threshold' => 1
-                }
-            }
+  def engine_conf
+    CC::Engine::Analyzers::EngineConfig.new({
+      'config' => {
+        'languages' => {
+          'javascript' => {
+            'mass_threshold' => 1
           }
-        })
-      end
-    end
+        }
+      }
+    })
   end
 end

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -1,4 +1,3 @@
-require 'spec_helper'
 require 'cc/engine/analyzers/php/main'
 require 'cc/engine/analyzers/reporter'
 require 'cc/engine/analyzers/engine_config'
@@ -6,21 +5,21 @@ require 'cc/engine/analyzers/file_list'
 require 'flay'
 require 'tmpdir'
 
-module CC::Engine::Analyzers::Php
-  describe Main do
-    before do
-      @code = Dir.mktmpdir
-      Dir.chdir(@code)
+RSpec.describe CC::Engine::Analyzers::Php::Main do
+  around do |example|
+    Dir.mktmpdir do |directory|
+      @code = directory
+
+      Dir.chdir(directory) do
+        example.run
+      end
     end
+  end
 
-    after do
-      FileUtils.rm_rf(@code)
-    end
+  describe "#run" do
+    it "prints an issue" do
 
-    describe "#run" do
-      it "prints an issue" do
-
-        create_source_file("foo.php", <<-EOPHP)
+      create_source_file("foo.php", <<-EOPHP)
           <?php
           function hello($name) {
             if (empty($name)) {
@@ -37,42 +36,41 @@ module CC::Engine::Analyzers::Php
               echo "Hi $name!";
             }
           }
-        EOPHP
+      EOPHP
 
-        assert_equal run_engine(engine_conf), printed_issue
-      end
-
-      def create_source_file(path, content)
-        File.write(File.join(@code, path), content)
-      end
-
-      def run_engine(config = nil)
-        io = StringIO.new
-
-        engine = ::CC::Engine::Analyzers::Php::Main.new(engine_config: config)
-        reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
-
-        reporter.run
-
-        io.string
-      end
-
-      def printed_issue
-        issue = {"type":"issue","check_name":"Identical code","description":"Similar code found in 1 other location","categories":["Duplication"],"location":{"path":"foo.php","lines":{"begin":2,"end":6}},"remediation_points":176000,"other_locations":[{"path":"foo.php","lines":{"begin":10,"end":14}}],"content":{"body": read_up}}
-        issue.to_json + "\0\n"
-      end
-
-      def engine_conf
-        CC::Engine::Analyzers::EngineConfig.new({
-          'config' => {
-            'languages' => {
-              'php' => {
-                'mass_threshold' => 5
-              }
-            }
-          }
-        })
-      end
+      expect(run_engine(engine_conf)).to eq(printed_issue)
     end
+  end
+
+  def create_source_file(path, content)
+    File.write(File.join(@code, path), content)
+  end
+
+  def run_engine(config = nil)
+    io = StringIO.new
+
+    engine = ::CC::Engine::Analyzers::Php::Main.new(engine_config: config)
+    reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
+
+    reporter.run
+
+    io.string
+  end
+
+  def printed_issue
+    issue = {"type":"issue","check_name":"Identical code","description":"Similar code found in 1 other location","categories":["Duplication"],"location":{"path":"foo.php","lines":{"begin":2,"end":6}},"remediation_points":176000,"other_locations":[{"path":"foo.php","lines":{"begin":10,"end":14}}],"content":{"body": read_up}}
+    issue.to_json + "\0\n"
+  end
+
+  def engine_conf
+    CC::Engine::Analyzers::EngineConfig.new({
+      'config' => {
+        'languages' => {
+          'php' => {
+            'mass_threshold' => 5
+          }
+        }
+      }
+    })
   end
 end

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -5,60 +5,59 @@ require 'cc/engine/analyzers/file_list'
 require "flay"
 require "tmpdir"
 
-module CC::Engine::Analyzers::Python
-  describe Main do
-    before do
-      @code = Dir.mktmpdir
-      Dir.chdir(@code)
+RSpec.describe CC::Engine::Analyzers::Python::Main do
+  around do |example|
+    Dir.mktmpdir do |directory|
+      @code = directory
+
+      Dir.chdir(directory) do
+        example.run
+      end
     end
+  end
 
-    after do
-      FileUtils.rm_rf(@code)
+  describe "#run" do
+    it "prints an issue" do
+
+      create_source_file("foo.py", <<-EOJS)
+print("Hello", "python")
+print("Hello", "python")
+print("Hello", "python")
+      EOJS
+
+      expect(run_engine(engine_conf)).to eq(printed_issue)
     end
+  end
 
-    describe "#run" do
-      it "prints an issue" do
+  def create_source_file(path, content)
+    File.write(File.join(@code, path), content)
+  end
 
-        create_source_file("foo.py", <<-EOJS)
-print("Hello", "python")
-print("Hello", "python")
-print("Hello", "python")
-        EOJS
+  def run_engine(config = nil)
+    io = StringIO.new
 
-        assert_equal run_engine(engine_conf), printed_issue
-      end
+    engine = ::CC::Engine::Analyzers::Python::Main.new(engine_config: config)
+    reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
 
-      def create_source_file(path, content)
-        File.write(File.join(@code, path), content)
-      end
+    reporter.run
 
-      def run_engine(config = nil)
-        io = StringIO.new
+    io.string
+  end
 
-        engine = ::CC::Engine::Analyzers::Python::Main.new(engine_config: config)
-        reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
+  def printed_issue
+    issue = {"type":"issue","check_name":"Identical code","description":"Similar code found in 2 other locations","categories":["Duplication"],"location":{"path":"foo.py","lines":{"begin":1,"end":1}},"remediation_points":81000, "other_locations":[{"path":"foo.py","lines":{"begin":2,"end":2}},{"path":"foo.py","lines":{"begin":3,"end":3}}], "content":{"body": read_up}}
+    issue.to_json + "\0\n"
+  end
 
-        reporter.run
-
-        io.string
-      end
-
-      def printed_issue
-        issue = {"type":"issue","check_name":"Identical code","description":"Similar code found in 2 other locations","categories":["Duplication"],"location":{"path":"foo.py","lines":{"begin":1,"end":1}},"remediation_points":81000, "other_locations":[{"path":"foo.py","lines":{"begin":2,"end":2}},{"path":"foo.py","lines":{"begin":3,"end":3}}], "content":{"body": read_up}}
-        issue.to_json + "\0\n"
-      end
-
-      def engine_conf
-        CC::Engine::Analyzers::EngineConfig.new({
-          "config" => {
-            "languages" => {
-              "python" => {
-                "mass_threshold" => 4
-              }
-            }
+  def engine_conf
+    CC::Engine::Analyzers::EngineConfig.new({
+      "config" => {
+        "languages" => {
+          "python" => {
+            "mass_threshold" => 4
           }
-        })
-      end
-    end
+        }
+      }
+    })
   end
 end

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -1,24 +1,23 @@
-require 'spec_helper'
 require 'cc/engine/analyzers/ruby/main'
 require 'cc/engine/analyzers/engine_config'
 require 'cc/engine/analyzers/file_list'
 require 'flay'
 require 'tmpdir'
 
-module CC::Engine::Analyzers::Ruby
-  describe Main do
-    before do
-      @code = Dir.mktmpdir
-      Dir.chdir(@code)
-    end
+RSpec.describe CC::Engine::Analyzers::Ruby::Main do
+  around do |example|
+    Dir.mktmpdir do |directory|
+      @code = directory
 
-    after do
-      FileUtils.rm_rf(@code)
+      Dir.chdir(directory) do
+        example.run
+      end
     end
+  end
 
-    describe "#run" do
-      it "prints an issue" do
-        create_source_file("foo.rb", <<-EORUBY)
+  describe "#run" do
+    it "prints an issue" do
+      create_source_file("foo.rb", <<-EORUBY)
           describe '#ruby?' do
             before { subject.type = 'ruby' }
 
@@ -34,46 +33,43 @@ module CC::Engine::Analyzers::Ruby
               expect(subject.js?).to be true
             end
           end
-        EORUBY
+      EORUBY
 
-        assert_equal run_engine, printed_issues
-      end
-
-      it "skips unparsable files" do
-        create_source_file("foo.rb", <<-EORUBY)
-        ---
-        EORUBY
-
-        _, stderr = capture_io do
-          run_engine.must_equal("")
-        end
-
-        stderr.must_match("Skipping file")
-      end
-
-      def create_source_file(path, content)
-        File.write(File.join(@code, path), content)
-      end
-
-      def run_engine(config = {})
-        io = StringIO.new
-
-        config = CC::Engine::Analyzers::EngineConfig.new(config)
-        engine = ::CC::Engine::Analyzers::Ruby::Main.new(engine_config: config)
-        reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
-
-        reporter.run
-
-        io.string
-      end
-
-      def first_issue
-        {"type":"issue","check_name":"Similar code","description":"Similar code found in 1 other location","categories":["Duplication"],"location":{"path":"foo.rb","lines":{"begin":1,"end":5}},"remediation_points": 360000, "other_locations":[{"path":"foo.rb","lines":{"begin":9,"end":13}}], "content": {"body": read_up}}
-      end
-
-      def printed_issues
-        first_issue.to_json + "\0\n"
-      end
+      expect(run_engine).to eq(printed_issues)
     end
+
+    it "skips unparsable files" do
+      create_source_file("foo.rb", <<-EORUBY)
+        ---
+      EORUBY
+
+      expect {
+        expect(run_engine).to eq("")
+      }.to output(/Skipping file/).to_stderr
+    end
+  end
+
+  def create_source_file(path, content)
+    File.write(File.join(@code, path), content)
+  end
+
+  def run_engine(config = {})
+    io = StringIO.new
+
+    config = CC::Engine::Analyzers::EngineConfig.new(config)
+    engine = ::CC::Engine::Analyzers::Ruby::Main.new(engine_config: config)
+    reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
+
+    reporter.run
+
+    io.string
+  end
+
+  def first_issue
+    {"type":"issue","check_name":"Similar code","description":"Similar code found in 1 other location","categories":["Duplication"],"location":{"path":"foo.rb","lines":{"begin":1,"end":5}},"remediation_points": 360000, "other_locations":[{"path":"foo.rb","lines":{"begin":9,"end":13}}], "content": {"body": read_up}}
+  end
+
+  def printed_issues
+    first_issue.to_json + "\0\n"
   end
 end

--- a/spec/cc/engine/duplication_spec.rb
+++ b/spec/cc/engine/duplication_spec.rb
@@ -1,20 +1,25 @@
 require "spec_helper"
 require "cc/engine/duplication"
 
-module CC::Engine
+RSpec.describe CC::Engine do
+  around do |example|
+    Dir.mktmpdir do |directory|
+      @directory = directory
+      example.run
+    end
+  end
+
   describe "#languages" do
     it "Warns to stderr and raises an exception when no languages are enabled" do
-      directory = Dir.mktmpdir
+      original_directory = Dir.pwd
+      engine = CC::Engine::Duplication.new(directory: @directory, engine_config: {}, io: StringIO.new)
 
-      engine = Duplication.new(directory: directory, engine_config: {}, io: StringIO.new)
+      expected_output = "Config Error: Unable to run the duplication engine without any languages enabled.\n"
+      expect {
+        expect { engine.run }.to raise_error(CC::Engine::Duplication::EmptyLanguagesError)
+      }.to output(expected_output).to_stderr
 
-      _, stderr = capture_io do
-        assert_raises(Duplication::EmptyLanguagesError) { engine.run }
-      end
-
-      stderr.must_match("Config Error: Unable to run the duplication engine without any languages enabled.")
-
-      FileUtils.rm_rf(directory)
+      Dir.chdir(original_directory)
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,16 +1,18 @@
-require 'minitest/spec'
-require 'minitest/autorun'
-require 'minitest/reporters'
-require 'minitest/unit'
-Minitest::Reporters.use! Minitest::Reporters::DefaultReporter.new
+require 'tmpdir'
 
-def read_up
-  File.read(read_up_path)
-end
+Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
 
-def read_up_path
-  relative_path = "../config/contents/duplicated_code.md"
-  File.expand_path(
-    File.join(File.dirname(__FILE__), relative_path)
-  )
+RSpec.configure do |config|
+  config.expect_with :rspec do |expectations|
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
+
+  config.order = :random
+  config.disable_monkey_patching!
+
+  config.include ReadUpHelpers
 end

--- a/spec/support/helpers/read_up_helpers.rb
+++ b/spec/support/helpers/read_up_helpers.rb
@@ -1,0 +1,12 @@
+module ReadUpHelpers
+  def read_up
+    File.read(read_up_path)
+  end
+
+  def read_up_path
+    relative_path = "../../../config/contents/duplicated_code.md"
+    File.expand_path(
+      File.join(File.dirname(__FILE__), relative_path)
+    )
+  end
+end

--- a/test/cc/engine/analyzers/engine_config_spec.rb
+++ b/test/cc/engine/analyzers/engine_config_spec.rb
@@ -1,0 +1,112 @@
+require "spec_helper"
+require "cc/engine/analyzers/engine_config"
+require "cc/engine/analyzers/ruby/main"
+
+module CC::Engine::Analyzers
+  describe EngineConfig do
+    describe "#config" do
+      it "normalizes language config" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "EliXiR" => {
+                "mass_threshold" => 15
+              }
+            }
+          }
+        })
+
+        assert_equal engine_config.languages, { "elixir" =>  { "mass_threshold" => 15 } }
+      end
+
+      it "transforms language arrays into empty hashes" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => [
+              "EliXiR",
+              "RubY"
+            ]
+          }
+        })
+
+        assert_equal engine_config.languages, { "elixir" =>  {}, "ruby" => {} }
+      end
+
+      it "returns an empty hash if languages is invalid" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => "potato",
+          }
+        })
+
+        assert_equal engine_config.languages, {}
+      end
+    end
+
+    describe "#paths_for" do
+      it "returns paths values for given language" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "EliXiR" => {
+                "paths" => ["/", "/etc"],
+              }
+            }
+          }
+        })
+
+        assert_equal engine_config.paths_for("elixir"), ["/", "/etc"]
+      end
+
+      it "returns nil if language is an empty key" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "EliXiR" => ""
+            }
+          }
+        })
+
+        assert_equal engine_config.paths_for("elixir"), nil
+      end
+    end
+
+    describe "mass_threshold_for" do
+      it "returns configured mass threshold as integer" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "EliXiR" => {
+                "mass_threshold" => "13"
+              }
+            }
+          }
+        })
+
+        assert_equal engine_config.mass_threshold_for("elixir"), 13
+      end
+
+      it "returns nil when language is empty" do
+        engine_config = EngineConfig.new({
+          "config" => {
+            "languages" => {
+              "ruby" => "",
+            }
+          }
+        })
+
+        assert_equal engine_config.mass_threshold_for("ruby"), nil
+      end
+    end
+
+    describe "exlude_paths" do
+      it "returns given exclude paths" do
+        engine_config = EngineConfig.new({
+          "exclude_paths" => ["/tmp"]
+        })
+
+        assert_equal engine_config.exclude_paths, ["/tmp"]
+      end
+    end
+  end
+end

--- a/test/cc/engine/analyzers/file_list_spec.rb
+++ b/test/cc/engine/analyzers/file_list_spec.rb
@@ -1,0 +1,83 @@
+require "spec_helper"
+require "cc/engine/analyzers/file_list"
+require "cc/engine/analyzers/engine_config"
+
+module CC::Engine::Analyzers
+  describe FileList do
+    before do
+      @tmp_dir = Dir.mktmpdir
+      Dir.chdir(@tmp_dir)
+
+      File.write(File.join(@tmp_dir, "foo.js"), "")
+      File.write(File.join(@tmp_dir, "foo.jsx"), "")
+      File.write(File.join(@tmp_dir, "foo.ex"), "")
+    end
+
+    after do
+      FileUtils.rm_rf(@tmp_dir)
+    end
+
+    describe "#files" do
+      it "returns files from default_paths when language is missing paths" do
+        file_list = ::CC::Engine::Analyzers::FileList.new(
+          engine_config: EngineConfig.new({}),
+          default_paths: ["**/*.js", "**/*.jsx"],
+          language: "javascript",
+        )
+
+        assert_equal file_list.files, ["./foo.js", "./foo.jsx"]
+      end
+
+      it "returns files from engine config defined paths when present" do
+        file_list = ::CC::Engine::Analyzers::FileList.new(
+          engine_config: EngineConfig.new({
+            "config" => {
+              "languages" => {
+                "elixir" => {
+                  "paths" => ["**/*.ex"]
+                }
+              }
+            }
+          }),
+          default_paths: ["**/*.js", "**/*.jsx"],
+          language: "elixir",
+        )
+
+        assert_equal file_list.files, ["./foo.ex"]
+      end
+
+      it "returns files from default_paths when languages is an array" do
+        file_list = ::CC::Engine::Analyzers::FileList.new(
+          engine_config: EngineConfig.new({
+            "config" => {
+              "languages" => [
+                "elixir"
+              ],
+            },
+          }),
+          default_paths: ["**/*.js", "**/*.jsx"],
+          language: "javascript",
+        )
+
+        assert_equal file_list.files, ["./foo.js", "./foo.jsx"]
+      end
+
+      it "excludes files from paths in exclude_files" do
+        file_list = ::CC::Engine::Analyzers::FileList.new(
+          engine_config: EngineConfig.new({
+            "exclude_paths" => ["**/*.js"],
+            "config" => {
+              "languages" => [
+                "elixir"
+              ],
+            },
+          }),
+          default_paths: ["**/*.js", "**/*.jsx"],
+          language: "javascript",
+        )
+
+        assert_equal file_list.files, ["./foo.jsx"]
+      end
+    end
+  end
+end


### PR DESCRIPTION
This migrates the test suite to RSpec since minitest is missing basic
things like `expect` syntax, `around` blocks, and a few other features.

While Minitest has plugins that provide these features, RSpec comes with
these features out of the box and more. Most of us are also seemingly
more familiar with RSpec.