### PR TITLE
Replace exclude_paths with include_paths

### DIFF
--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -6,8 +6,8 @@ module CC
           @config = normalize(hash)
         end
 
-        def exclude_paths
-          config.fetch("exclude_paths", [])
+        def include_paths
+          config.fetch("include_paths", ["./"])
         end
 
         def languages

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -104,12 +104,12 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
   end
 
   describe "exlude_paths" do
-    it "returns given exclude paths" do
+    it "returns given include paths" do
       engine_config = CC::Engine::Analyzers::EngineConfig.new({
-        "exclude_paths" => ["/tmp"]
+        "include_paths" => ["/tmp"]
       })
 
-      expect(engine_config.exclude_paths).to eq(["/tmp"])
+      expect(engine_config.include_paths).to eq(["/tmp"])
     end
   end
 end

--- a/spec/cc/engine/analyzers/file_list_spec.rb
+++ b/spec/cc/engine/analyzers/file_list_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe CC::Engine::Analyzers::FileList do
       @tmp_dir = directory
 
       Dir.chdir(@tmp_dir) do
+        Dir.mkdir("nested")
+        File.write(File.join(@tmp_dir, "nested", "nest.hs"), "")
+
         File.write(File.join(@tmp_dir, "foo.js"), "")
         File.write(File.join(@tmp_dir, "foo.jsx"), "")
         File.write(File.join(@tmp_dir, "foo.ex"), "")
@@ -62,21 +65,21 @@ RSpec.describe CC::Engine::Analyzers::FileList do
       expect(file_list.files).to eq(["./foo.js", "./foo.jsx"])
     end
 
-    it "excludes files from paths in exclude_files" do
+    it "excludes files not in include_paths" do
       file_list = ::CC::Engine::Analyzers::FileList.new(
         engine_config: CC::Engine::Analyzers::EngineConfig.new({
-          "exclude_paths" => ["**/*.js"],
+          "include_paths" => ["foo.jsx", "nested"],
           "config" => {
             "languages" => [
               "elixir"
             ],
           },
         }),
-        default_paths: ["**/*.js", "**/*.jsx"],
+        default_paths: ["**/*.js", "**/*.jsx", "**/*.hs"],
         language: "javascript",
       )
 
-      expect(file_list.files).to eq(["./foo.jsx"])
+      expect(file_list.files).to eq(["./foo.jsx", "./nested/nest.hs"])
     end
   end
 end


### PR DESCRIPTION
`exclude_paths` has been deprecated in favor of `include_paths`.

Since each language allows you to specify its own paths to look for
duplications we have to build an array of files that the `include_paths`
specifies and then intersect those files with the files that match the
languages specified paths.