### PR TITLE
Don't detect comments as duplication

### DIFF
--- a/lib/cc/engine/analyzers/javascript/parser.js
+++ b/lib/cc/engine/analyzers/javascript/parser.js
@@ -6,6 +6,7 @@ var source = "";
 var toScrub = [
   'leadingComments',
   'trailingComments',
+  'innerComments',
   'shadow',
   'start',
   'end',

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main do
     end
   end
 
+  it "does not flag duplicate comments" do
+      create_source_file("foo.js", <<-EOJS)
+        // A comment.
+        // A comment.
+
+        /* A comment. */
+        /* A comment. */
+      EOJS
+
+      expect(run_engine(engine_conf)).to be_empty
+  end
+
   def create_source_file(path, content)
     File.write(File.join(@code, path), content)
   end


### PR DESCRIPTION
Scrubs innerComment nodes from the parse result to prevent comments from being considered duplication when analyzing JavaScript.