### PR TITLE
Add concurrency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+
 FROM alpine:edge
 
 WORKDIR /usr/src/app/
@@ -8,8 +9,9 @@ COPY Gemfile.lock /usr/src/app/
 COPY vendor/php-parser/composer.json /usr/src/app/vendor/php-parser/
 COPY vendor/php-parser/composer.lock /usr/src/app/vendor/php-parser/
 
-RUN apk --update add git python nodejs php-cli php-json php-phar php-openssl php-xml curl\
-    ruby ruby-io-console ruby-dev ruby-bundler build-base && \
+RUN apk --update add openssh git python nodejs php-cli php-json php-phar php-openssl php-xml curl\
+    ruby ruby-io-console ruby-dev build-base && \
+    gem install bundler --no-ri --no-rdoc && \
     bundle install -j 4 && \
     apk del build-base && rm -fr /usr/share/ri && \
     curl -sS https://getcomposer.org/installer | php

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 source 'https://rubygems.org'
 
-gem 'flay'
+gem 'flay', git: 'https://github.com/codeclimate/flay.git'
+gem 'concurrent-ruby', "~> 1.0.0.pre4"
+gem 'ruby_parser'
 gem 'pry'
 gem 'posix-spawn'
 gem 'sexp_processor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,19 @@
+GIT
+  remote: https://github.com/codeclimate/flay.git
+  revision: e6e472e064dc459277f8bd57167789f8fed77f56
+  specs:
+    flay (2.6.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.0)
+    concurrent-ruby (1.0.0.pre4)
     diff-lcs (1.2.5)
-    flay (2.6.1)
-      ruby_parser (~> 3.0)
-      sexp_processor (~> 4.0)
     json (1.8.3)
     method_source (0.8.2)
     posix-spawn (0.3.11)
-    pry (0.10.1)
+    pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
@@ -27,7 +31,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    ruby_parser (3.7.1)
+    ruby_parser (3.7.2)
       sexp_processor (~> 4.1)
     sexp_processor (4.6.0)
     slop (3.6.0)
@@ -36,12 +40,14 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  flay
+  concurrent-ruby (~> 1.0.0.pre4)
+  flay!
   json
   posix-spawn
   pry
   rake
   rspec
+  ruby_parser
   sexp_processor
 
 BUNDLED WITH

--- a/circle.yml
+++ b/circle.yml
@@ -5,9 +5,13 @@ machine:
     CLOUDSDK_CORE_DISABLE_PROMPTS: 1
     PRIVATE_REGISTRY: us.gcr.io/code_climate
 
+dependencies:
+  override:
+    - docker info
+    - docker build -t=$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
+
 test:
   override:
-    - docker build -t=$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
     - docker run $PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM bundle exec rake
 
 deployment:

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -6,15 +6,15 @@ module CC
           @engine_config = engine_config
         end
 
-        def run
-          files.map do |file|
-            begin
-              process_file(file)
-            rescue => ex
-              $stderr.puts "Skipping file #{file} due to exception"
-              $stderr.puts "(#{ex.class}) #{ex.message} #{ex.backtrace.join("\n")}"
-            end
-          end
+        def run(file)
+          process_file(file)
+        rescue => ex
+          $stderr.puts "Skipping file #{file} due to exception"
+          $stderr.puts "(#{ex.class}) #{ex.message} #{ex.backtrace.join("\n")}"
+        end
+
+        def files
+          file_list.files
         end
 
         def mass_threshold
@@ -33,12 +33,12 @@ module CC
           raise NoMethodError.new("Subclass must implement `process_file`")
         end
 
-        def files
-          ::CC::Engine::Analyzers::FileList.new(
+        def file_list
+          @_file_list ||= ::CC::Engine::Analyzers::FileList.new(
             engine_config: engine_config,
             default_paths: self.class::DEFAULT_PATHS,
             language: self.class::LANGUAGE
-          ).files
+          )
         end
       end
     end

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -14,6 +14,10 @@ module CC
           config.fetch("languages", {})
         end
 
+        def concurrency
+          config.fetch("concurrency", 2)
+        end
+
         def mass_threshold_for(language)
           threshold = fetch_language(language).fetch("mass_threshold", nil)
 

--- a/lib/cc/engine/analyzers/file_thread_pool.rb
+++ b/lib/cc/engine/analyzers/file_thread_pool.rb
@@ -1,0 +1,58 @@
+require "thread"
+
+module CC
+  module Engine
+    module Analyzers
+      class FileThreadPool
+        DEFAULT_CONCURRENCY = 2
+        MAX_CONCURRENCY = 2
+
+        def initialize(files, concurrency: DEFAULT_CONCURRENCY)
+          @files = files
+          @concurrency = concurrency
+        end
+
+        def run(&block)
+          queue = build_queue
+
+          @workers = thread_count.times.map do
+            Thread.new do
+              begin 
+                while item = queue.pop(true)
+                  yield item
+                end
+              rescue ThreadError
+              end
+            end
+          end
+        end
+
+        def join
+          workers.map(&:join)
+        end
+
+        private
+
+        attr_reader :files, :concurrency, :workers
+
+        def build_queue
+          Queue.new.tap do |queue|
+            files.each do |file|
+              queue.push(file)
+            end
+          end
+        end
+
+        def thread_count
+          if (1..MAX_CONCURRENCY) === concurrency
+            concurrency
+          elsif concurrency < 1
+            DEFAULT_CONCURRENCY
+          else
+            DEFAULT_CONCURRENCY
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -18,7 +18,6 @@ module CC
           DEFAULT_MASS_THRESHOLD = 40
           BASE_POINTS = 3000
 
-
           private
 
           def process_file(path)

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -15,7 +15,7 @@ module CC
           DEFAULT_MASS_THRESHOLD = 40
           BASE_POINTS = 1000
 
-          attr_reader :directory, :engine_config
+          private
 
           def process_file(path)
             Node.new(::CC::Engine::Analyzers::Python::Parser.new(File.binread(path), path).parse.syntax_tree, path).format

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -23,8 +23,6 @@ module CC
 
           private
 
-          attr_reader :directory, :engine_config
-
           def process_file(file)
             RubyParser.new.process(File.binread(file), file, TIMEOUT)
           end
@@ -33,4 +31,3 @@ module CC
     end
   end
 end
-

--- a/lib/cc/engine/duplication.rb
+++ b/lib/cc/engine/duplication.rb
@@ -29,7 +29,7 @@ module CC
       def run
         languages_to_analyze.each do |language|
           engine = LANGUAGES[language].new(engine_config: engine_config)
-          reporter = CC::Engine::Analyzers::Reporter.new(engine, io)
+          reporter = CC::Engine::Analyzers::Reporter.new(engine_config, engine, io)
           reporter.run
         end
       end

--- a/spec/cc/engine/analyzers/file_thread_pool_spec.rb
+++ b/spec/cc/engine/analyzers/file_thread_pool_spec.rb
@@ -1,0 +1,69 @@
+require "spec_helper"
+require "cc/engine/analyzers/file_thread_pool"
+
+RSpec.describe CC::Engine::Analyzers::FileThreadPool do
+  describe "#run" do
+    it "uses default count of threads when concurrency is not specified" do
+      allow(Thread).to receive(:new)
+
+      pool = CC::Engine::Analyzers::FileThreadPool.new([])
+      pool.run  {}
+
+      expect(Thread).to have_received(:new).exactly(
+        CC::Engine::Analyzers::FileThreadPool::DEFAULT_CONCURRENCY
+      ).times
+    end
+
+    it "uses default concurrency when concurrency is over max" do
+      allow(Thread).to receive(:new)
+
+      run_pool_with_concurrency(
+        CC::Engine::Analyzers::FileThreadPool::DEFAULT_CONCURRENCY + 2
+      )
+
+      expect(Thread).to have_received(:new).exactly(
+        CC::Engine::Analyzers::FileThreadPool::DEFAULT_CONCURRENCY
+      ).times
+    end
+
+    it "uses default concucurrency when concucurrency is under 1" do
+      allow(Thread).to receive(:new)
+
+      run_pool_with_concurrency(-2)
+
+      expect(Thread).to have_received(:new).exactly(
+        CC::Engine::Analyzers::FileThreadPool::DEFAULT_CONCURRENCY
+      ).times
+    end
+
+    it "uses supplied concurrency when valid" do
+      allow(Thread).to receive(:new)
+
+      run_pool_with_concurrency(1)
+
+      expect(Thread).to have_received(:new).exactly(1).times
+    end
+
+    it "calls block for each file" do
+      pool = CC::Engine::Analyzers::FileThreadPool.new(["abc", "123", "xyz"])
+
+      results = []
+      pool.run do |f|
+        results.push f.reverse
+      end
+      pool.join
+
+      expect(results).to include("cba")
+      expect(results).to include("321")
+      expect(results).to include("zyx")
+    end
+  end
+
+  def run_pool_with_concurrency(concurrency)
+      pool = CC::Engine::Analyzers::FileThreadPool.new(
+        [],
+        concurrency: concurrency
+      )
+      pool.run  {}
+  end
+end

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main do
     io = StringIO.new
 
     engine = ::CC::Engine::Analyzers::Javascript::Main.new(engine_config: config)
-    reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
+    reporter = ::CC::Engine::Analyzers::Reporter.new(double(concurrency: 2), engine, io)
 
     reporter.run
 

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main do
     io = StringIO.new
 
     engine = ::CC::Engine::Analyzers::Php::Main.new(engine_config: config)
-    reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
+    reporter = ::CC::Engine::Analyzers::Reporter.new(double(concurrency: 2), engine, io)
 
     reporter.run
 

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -54,7 +54,7 @@ print("Hello", "python")
     io = StringIO.new
 
     engine = ::CC::Engine::Analyzers::Python::Main.new(engine_config: config)
-    reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
+    reporter = ::CC::Engine::Analyzers::Reporter.new(double(concurrency: 2), engine, io)
 
     reporter.run
 

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -74,7 +74,7 @@ RSpec.describe CC::Engine::Analyzers::Ruby::Main do
 
     config = CC::Engine::Analyzers::EngineConfig.new(config)
     engine = ::CC::Engine::Analyzers::Ruby::Main.new(engine_config: config)
-    reporter = ::CC::Engine::Analyzers::Reporter.new(engine, io)
+    reporter = ::CC::Engine::Analyzers::Reporter.new(double(concurrency: 2), engine, io)
 
     reporter.run
 


### PR DESCRIPTION
Adds thread-based concurrency to the parsing and `process_sexp` phase (but not the "report" phase at the end). Concurrency is implemented using a vanilla Ruby `Queue` and threads. The concurrency is configurable in the engine config (which I think we will want to add to the spec, and defaults to 2).

This uses the `Concurrent::Array`, `Concurrent::Hash` and `Concurrent::Map` classes from the `concurrent-ruby` gem for thread safe data structures in Flay (which is why I unpacked `flay.rb` from the Gem dependency to patch it.

We should consider submitting a concurrency patch upstream after we test this more. It will require some re-work but it's manageable.

_Note:_ The last step is switching the Ruby interpreter from MRI to JRuby in the Dockerfile (but this should produce wins even on MRI for non-Ruby languages due to the concurrent parsing in the e.g. Node.js processes we boot).

/c @jpignata 