### PR TITLE
Add fingerprint to violation json

### DIFF
--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -38,7 +38,23 @@ RSpec.describe CC::Engine::Analyzers::Php::Main do
           }
       EOPHP
 
-      expect(run_engine(engine_conf)).to eq(printed_issue)
+      result = run_engine(engine_conf).strip
+      json = JSON.parse(result)
+
+      expect(json["type"]).to eq("issue")
+      expect(json["check_name"]).to eq("Identical code")
+      expect(json["description"]).to eq("Similar code found in 1 other location")
+      expect(json["categories"]).to eq(["Duplication"])
+      expect(json["location"]).to eq({
+        "path" => "foo.php",
+        "lines" => { "begin" => 2, "end" => 6 },
+      })
+      expect(json["remediation_points"]).to eq(176000)
+      expect(json["other_locations"]).to eq([
+        {"path" => "foo.php", "lines" => { "begin" => 10, "end" => 14} },
+      ])
+      expect(json["content"]).to eq({ "body" => read_up })
+      expect(json["fingerprint"]).to eq("667da0e2bab866aa2fe9d014a65d57d9")
     end
   end
 

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -25,7 +25,24 @@ print("Hello", "python")
 print("Hello", "python")
       EOJS
 
-      expect(run_engine(engine_conf)).to eq(printed_issue)
+      result = run_engine(engine_conf).strip
+      json = JSON.parse(result)
+
+      expect(json["type"]).to eq("issue")
+      expect(json["check_name"]).to eq("Identical code")
+      expect(json["description"]).to eq("Similar code found in 2 other locations")
+      expect(json["categories"]).to eq(["Duplication"])
+      expect(json["location"]).to eq({
+        "path" => "foo.py",
+        "lines" => { "begin" => 1, "end" => 1 },
+      })
+      expect(json["remediation_points"]).to eq(81000)
+      expect(json["other_locations"]).to eq([
+        {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
+        {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} }
+      ])
+      expect(json["content"]).to eq({ "body" => read_up })
+      expect(json["fingerprint"]).to eq("f62657986e3b81235ed8638aac833886")
     end
   end
 
@@ -42,11 +59,6 @@ print("Hello", "python")
     reporter.run
 
     io.string
-  end
-
-  def printed_issue
-    issue = {"type":"issue","check_name":"Identical code","description":"Similar code found in 2 other locations","categories":["Duplication"],"location":{"path":"foo.py","lines":{"begin":1,"end":1}},"remediation_points":81000, "other_locations":[{"path":"foo.py","lines":{"begin":2,"end":2}},{"path":"foo.py","lines":{"begin":3,"end":3}}], "content":{"body": read_up}}
-    issue.to_json + "\0\n"
   end
 
   def engine_conf

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -35,7 +35,23 @@ RSpec.describe CC::Engine::Analyzers::Ruby::Main do
           end
       EORUBY
 
-      expect(run_engine).to eq(printed_issues)
+      result = run_engine.strip
+      json = JSON.parse(result)
+
+      expect(json["type"]).to eq("issue")
+      expect(json["check_name"]).to eq("Similar code")
+      expect(json["description"]).to eq("Similar code found in 1 other location")
+      expect(json["categories"]).to eq(["Duplication"])
+      expect(json["location"]).to eq({
+        "path" => "foo.rb",
+        "lines" => { "begin" => 1, "end" => 5 },
+      })
+      expect(json["remediation_points"]).to eq(360000)
+      expect(json["other_locations"]).to eq([
+        {"path" => "foo.rb", "lines" => { "begin" => 9, "end" => 13} },
+      ])
+      expect(json["content"]).to eq({ "body" => read_up })
+      expect(json["fingerprint"]).to eq("f21b75bbd135ec3ae6638364d5c73762")
     end
 
     it "skips unparsable files" do
@@ -63,13 +79,5 @@ RSpec.describe CC::Engine::Analyzers::Ruby::Main do
     reporter.run
 
     io.string
-  end
-
-  def first_issue
-    {"type":"issue","check_name":"Similar code","description":"Similar code found in 1 other location","categories":["Duplication"],"location":{"path":"foo.rb","lines":{"begin":1,"end":5}},"remediation_points": 360000, "other_locations":[{"path":"foo.rb","lines":{"begin":9,"end":13}}], "content": {"body": read_up}}
-  end
-
-  def printed_issues
-    first_issue.to_json + "\0\n"
   end
 end


### PR DESCRIPTION
This uses the first filename and the mass of the s-expression as the
fingerprint for duplications.

This also changes the tests to test properties instead of a comparing against a fixture like string.