### PR TITLE
Reduce node generated s-expression mass

### DIFF
--- a/lib/cc/engine/analyzers/node.rb
+++ b/lib/cc/engine/analyzers/node.rb
@@ -45,7 +45,7 @@ module CC
             elsif  value.is_a?(Hash)
               create_sexp(key.to_sym, self.class.new(value, @file, @line).format)
             else
-              create_sexp(key.to_sym, value)
+              value.to_s.to_sym
             end
           end
         end

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main do
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(378000)
+      expect(json["remediation_points"]).to eq(297000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} }
       ])
       expect(json["content"]).to eq({ "body" => read_up })
-      expect(json["fingerprint"]).to eq("c3828ce5cdcd85a5dc0108ebad4219ed")
+      expect(json["fingerprint"]).to eq("55ae5d0990647ef496e9e0d315f9727d")
     end
   end
 

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -36,13 +36,13 @@ print("Hello", "python")
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(81000)
+      expect(json["remediation_points"]).to eq(54000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} }
       ])
       expect(json["content"]).to eq({ "body" => read_up })
-      expect(json["fingerprint"]).to eq("f62657986e3b81235ed8638aac833886")
+      expect(json["fingerprint"]).to eq("42b832387c997f54a2012efb2159aefc")
     end
   end
 


### PR DESCRIPTION
Instead of creating an s-expression for each `key` => `value` in an
s-expression node we insert only `value` directly as a symbol which
reduces the s-expression count which reduces the mass.

We do this because the s-expression tree that is currently being
generated feels too heavy and can make trivial code mass higher than the
threshold when it should be below the threshold.

eg:

```
const hello = function(name) {
  console.log(`${name}!`);
};

hello("world");
```

The above code currently has a mass of 54. With this change
it's now has a mass of 41.