### PR TITLE
Switch from MRI to JRuby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-
-FROM alpine:edge
+FROM jruby:9.0.3-jdk
 
 WORKDIR /usr/src/app/
 
@@ -9,19 +8,19 @@ COPY Gemfile.lock /usr/src/app/
 COPY vendor/php-parser/composer.json /usr/src/app/vendor/php-parser/
 COPY vendor/php-parser/composer.lock /usr/src/app/vendor/php-parser/
 
-RUN apk --update add openssh git python nodejs php-cli php-json php-phar php-openssl php-xml curl\
-    ruby ruby-io-console ruby-dev build-base && \
-    gem install bundler --no-ri --no-rdoc && \
+RUN curl --silent --location https://deb.nodesource.com/setup_5.x | bash -
+RUN apt-get install -y nodejs python openssh-client php5-cli php5-json
+RUN gem install bundler --no-ri --no-rdoc && \
     bundle install -j 4 && \
-    apk del build-base && rm -fr /usr/share/ri && \
     curl -sS https://getcomposer.org/installer | php
 
 RUN mv composer.phar /usr/local/bin/composer
 RUN cd /usr/src/app/vendor/php-parser/ && composer install --prefer-source --no-interaction
 
-RUN adduser -u 9000 -D app
+RUN adduser app -u 9000
 
 COPY . /usr/src/app
+run chown -R app .
 RUN npm install
 
 USER app

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,6 @@ gem 'flay', git: 'https://github.com/codeclimate/flay.git'
 gem 'concurrent-ruby', "~> 1.0.0.pre4"
 gem 'ruby_parser'
 gem 'pry'
-gem 'posix-spawn'
 gem 'sexp_processor'
 gem 'json'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/codeclimate/flay.git
-  revision: e6e472e064dc459277f8bd57167789f8fed77f56
+  revision: ac8fd46ba30e9636e8bdc625cf5f849615d505b6
   specs:
     flay (2.6.1)
 
@@ -8,11 +8,10 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.0)
-    concurrent-ruby (1.0.0.pre4)
+    concurrent-ruby (1.0.0.pre5)
     diff-lcs (1.2.5)
     json (1.8.3)
     method_source (0.8.2)
-    posix-spawn (0.3.11)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -43,7 +42,6 @@ DEPENDENCIES
   concurrent-ruby (~> 1.0.0.pre4)
   flay!
   json
-  posix-spawn
   pry
   rake
   rspec

--- a/lib/cc/engine/analyzers/python/parser.rb
+++ b/lib/cc/engine/analyzers/python/parser.rb
@@ -1,4 +1,3 @@
-require 'posix/spawn'
 require 'timeout'
 require 'json'
 
@@ -42,10 +41,14 @@ module CC
 
           def run(input, timeout = DEFAULT_TIMEOUT)
             Timeout.timeout(timeout) do
-              child = ::POSIX::Spawn::Child.new(command, input: input, timeout: timeout)
+              IO.popen command, "r+" do |io|
+                io.puts input
+                io.close_write
 
-              if child.status.success?
-                yield child.out if block_given?
+                output = io.gets
+                io.close
+
+                yield output if $?.to_i == 0
               end
             end
           end


### PR DESCRIPTION
To take full advantage of concurrent-ruby for faster analyses this
replaces MRI Ruby with JRuby since JRuby can take advantage of threads
without being blocked by the GIL.

* Replace posix-spawn with `IO.popen`
* Replace alpine with `jruby:9.0-jdk` Docker image

Here's a comparison of JRuby vs MRI on a medium sized JavaScript
project using the same concurrency value and same config.

JRuby:

```
codeclimate analyze --dev  0.29s user 0.22s system 0% cpu 2:26.03 total
```

MRI:

```
codeclimate analyze --dev  0.35s user 0.29s system 0% cpu 3:54.92 total
```