### PR TITLE
Don't report same line for multiple duplications

### DIFF
--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -26,6 +26,10 @@ module CC
           }
         end
 
+        def report_name
+          "#{current_sexp.file}-#{current_sexp.line}"
+        end
+
         private
 
         attr_reader :base_points, :hashes

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -58,6 +58,16 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main do
       expect(run_engine(engine_conf)).to be_empty
   end
 
+  it "does not report the same line for multiple issues" do
+    create_source_file("dup.jsx", <<-EOJSX)
+          <a className='button button-primary full' href='#' onClick={this.onSubmit.bind(this)}>Login</a>
+    EOJSX
+
+    result = run_engine(engine_conf).strip
+    issues = result.split("\0")
+    expect(issues.length).to eq 1
+  end
+
   def create_source_file(path, content)
     File.write(File.join(@code, path), content)
   end


### PR DESCRIPTION
This uses Ruby's [`set`](http://ruby-doc.org/stdlib-2.2.3/libdoc/set/rdoc/Set.html) class
to keep track of which lines in every file is reported to prevent
reporting the same line multiple times.

This happens most frequently with JavaScript since the Babel generated
ast is verbose and can expand a single line into a large s-expression
tree which can have several duplications.