### PR TITLE
Don't report same line in other_locations

### DIFF
--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -66,7 +66,7 @@ module CC
 
         def new_violation(issue)
           hashes = flay.hashes[issue.structural_hash]
-          Violation.new(language_strategy.base_points, issue, hashes)
+          Violation.new(language_strategy.base_points, issue, hashes, reports)
         end
 
         def flay_options

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -6,10 +6,11 @@ module CC
       class Violation
         attr_reader :issue
 
-        def initialize(base_points, issue, hashes)
+        def initialize(base_points, issue, hashes, reports)
           @base_points = base_points
           @issue = issue
           @hashes = hashes
+          @reports = reports
         end
 
         def format
@@ -32,7 +33,7 @@ module CC
 
         private
 
-        attr_reader :base_points, :hashes
+        attr_reader :base_points, :hashes, :reports
 
         def current_sexp
           @location ||= sorted_hashes.first
@@ -43,7 +44,12 @@ module CC
         end
 
         def other_sexps
-          @other_locations ||= hashes.drop(1)
+          @_other_sexps ||= hashes.drop(1).reject do |hash|
+            report_name = "#{hash.file}-#{hash.line}"
+            reports.include?(report_name).tap do
+              reports.add(report_name)
+            end
+          end
         end
 
         def name

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -65,6 +65,11 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main do
 
     result = run_engine(engine_conf).strip
     issues = result.split("\0")
+
+    first_issue = issues.first
+    json = JSON.parse(first_issue)
+
+    expect(json["other_locations"].length).to eq(0)
     expect(issues.length).to eq 1
   end
 


### PR DESCRIPTION
This follows up on the PR for not reporting multiple duplications for
the same line and applied the same logic to `other_locations`.