### PR TITLE
Don't show snippet in other locations

### DIFF
--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -66,7 +66,7 @@ module CC
 
         def new_violation(issue)
           hashes = flay.hashes[issue.structural_hash]
-          Violation.new(language_strategy.base_points, issue, hashes, reports)
+          Violation.new(language_strategy.base_points, issue, hashes)
         end
 
         def flay_options

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -6,11 +6,10 @@ module CC
       class Violation
         attr_reader :issue
 
-        def initialize(base_points, issue, hashes, reports)
+        def initialize(base_points, issue, hashes)
           @base_points = base_points
           @issue = issue
           @hashes = hashes
-          @reports = reports
         end
 
         def format
@@ -33,7 +32,7 @@ module CC
 
         private
 
-        attr_reader :base_points, :hashes, :reports
+        attr_reader :base_points, :hashes
 
         def current_sexp
           @location ||= sorted_hashes.first
@@ -44,12 +43,7 @@ module CC
         end
 
         def other_sexps
-          @_other_sexps ||= hashes.drop(1).reject do |hash|
-            report_name = "#{hash.file}-#{hash.line}"
-            reports.include?(report_name).tap do
-              reports.add(report_name)
-            end
-          end
+          @other_locations ||= hashes.drop(1)
         end
 
         def name

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -43,7 +43,7 @@ module CC
         end
 
         def other_sexps
-          @other_locations ||= hashes.drop(1)
+          @other_locations ||= sorted_hashes.drop(1)
         end
 
         def name

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -65,11 +65,6 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main do
 
     result = run_engine(engine_conf).strip
     issues = result.split("\0")
-
-    first_issue = issues.first
-    json = JSON.parse(first_issue)
-
-    expect(json["other_locations"].length).to eq(0)
     expect(issues.length).to eq 1
   end
 


### PR DESCRIPTION
This reverts the previous attempt to exclude the current snippet from `other_locations`.
It's not always the first in `hashes`, but `current_sexp` uses the first
of the sorted array, so dropping that one is safe.

Covered by tests here:
https://github.com/codeclimate/codeclimate-duplication/blob/master/spec/cc/engine/analyzers/javascript/main_spec.rb#L41-42

@codeclimate/review 