### PR TITLE
Use babylon parser directly to disable strict mode

### DIFF
--- a/lib/cc/engine/analyzers/javascript/parser.js
+++ b/lib/cc/engine/analyzers/javascript/parser.js
@@ -1,4 +1,4 @@
-var babel = require('babel');
+var babylon = require("babylon");
 
 process.stdin.resume();
 
@@ -19,7 +19,7 @@ process.stdin.on('data', function(chunk) {
 });
 
 process.stdin.on('end', function() {
-  var ast = babel.transform(source).ast;
+  var ast = babylon.parse(source, { plugins: ["jsx"], strictMode: false, sourceType: "module" });
   var program = ast.program;
   console.log(
     JSON.stringify(format(program))

--- a/package.json
+++ b/package.json
@@ -8,6 +8,6 @@
     "url": "git@github.com:codeclimate/codeclimate-duplication.git"
   },
   "dependencies": {
-    "babel": "^5.8.23"
+    "babylon": "^6.1.2"
   }
 }


### PR DESCRIPTION
We shouldn't assume that all JavaScript analyzed by this engine will adhere to strict ES6 rules. Instead, use the parser as loosely as possible when analyzing for duplication.

```
/usr/src/app/node_modules/babel/node_modules/babel-core/lib/transformation/file/index.js:671
      throw err;
      ^

SyntaxError: unknown: Argument name clash in strict mode (54:39)
  52 |       chart.yAxis.tickFormat(function() { return ""; });
  53 |
> 54 |       chart.tooltipContent(function(_, _, _, graph) {
     |                                        ^
  55 |         var date = d3.time.format('%b-%d')(new Date(graph.point.x));
  56 |         return "<strong><span style=\"padding:5px;\">" + date + "</span></strong>";
  57 |       });
    at Parser.pp.raise (/usr/src/app/node_modules/babel/node_modules/babel-core/node_modules/babylon/lib/parser/location.js:24:13)
    at Parser.pp.checkLVal (/usr/src/app/node_modules/babel/node_modules/babel-core/node_modules/babylon/lib/parser/lval.js:181:16)
    at Parser.pp.parseFunctionBody (/usr/src/app/node_modules/babel/node_modules/babel-core/node_modules/babylon/lib/parser/expression.js:766:12)
    at Parser.parseFunctionBody (/usr/src/app/node_modules/babel/node_modules/babel-core/node_modules/babylon/lib/plugins/flow.js:609:20)
    at Parser.pp.parseFunction (/usr/src/app/node_modules/babel/node_modules/babel-core/node_modules/babylon/lib/parser/statement.js:524:8)
    at Parser.pp.parseExprAtom (/usr/src/app/node_modules/babel/node_modules/babel-core/node_modules/babylon/lib/parser/expression.js:397:19)
    at Parser.parseExprAtom (/usr/src/app/node_modules/babel/node_modules/babel-core/node_modules/babylon/lib/plugins/jsx/index.js:412:22)
    at Parser.pp.parseExprSubscripts (/usr/src/app/node_modules/babel/node_modules/babel-core/node_modules/babylon/lib/parser/expression.js:236:19)
    at Parser.pp.parseMaybeUnary (/usr/src/app/node_modules/babel/node_modules/babel-core/node_modules/babylon/lib/parser/expression.js:217:19)
    at Parser.pp.parseExprOps (/usr/src/app/node_modules/babel/node_modules/babel-core/node_modules/babylon/lib/parser/expression.js:163:19)
```