### PR TITLE
Change directory with a block while running the reporter

### DIFF
--- a/lib/cc/engine/duplication.rb
+++ b/lib/cc/engine/duplication.rb
@@ -22,22 +22,24 @@ module CC
       }.freeze
 
       def initialize(directory:, engine_config:, io:)
-        Dir.chdir(directory)
+        @directory = directory
         @engine_config = CC::Engine::Analyzers::EngineConfig.new(engine_config || {})
         @io = io
       end
 
       def run
-        languages_to_analyze.each do |language|
-          engine = LANGUAGES[language].new(engine_config: engine_config)
-          reporter = CC::Engine::Analyzers::Reporter.new(engine_config, engine, io)
-          reporter.run
+        Dir.chdir(directory) do
+          languages_to_analyze.each do |language|
+            engine = LANGUAGES[language].new(engine_config: engine_config)
+            reporter = CC::Engine::Analyzers::Reporter.new(engine_config, engine, io)
+            reporter.run
+          end
         end
       end
 
       private
 
-      attr_reader :engine_config, :io
+      attr_reader :directory, :engine_config, :io
 
       def languages_to_analyze
         languages.select do |language|


### PR DESCRIPTION
I experienced some weirdness recently with the error described in #40 showing up multiple times in the container logs. Using the block form of chdir seems to have removed that repetition, with just one expected occurrence showing up. I wonder if there's some strangess around changing directories and multiple jruby threads that I still don't understand, but using the block form seems to be a safe move.

Thoughts?