### PR TITLE
Set JVM heap size options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,6 @@ RUN npm install
 
 USER app
 
+ENV JAVA_OPTS="-Xms384m -Xmx384m"
+
 CMD ["/usr/src/app/bin/duplication"]


### PR DESCRIPTION
We're seeing the duplication engine being killed for memory consumption
in production while analyzing medium-sized repositories. This change
sets an initial and maximum heap space of 384MB. This will keep us
under the memory limit while leaving additional working memory for
other processes.

--

This is kind of a shot in the dark. We're seeing this behavior only in production and not in the CLI. Thoughts, @codeclimate/review?