### PR TITLE
Reduce java memory options to 128M

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ RUN npm install
 
 USER app
 
-ENV JAVA_OPTS="-Xms384m -Xmx384m"
+ENV JAVA_OPTS="-Xms128m -Xmx128m"
 
 CMD ["/usr/src/app/bin/duplication"]


### PR DESCRIPTION
These numbers were (and still are) a bit of a shot in the dark:

1. This cannot limit total process memory; it's technically a limit on the
   JVM's heap size, which will indirectly impact total process memory[1]

2. With the previous limit of 384M, it's suspected a fork operation
   would require double that (768M), which is already over the 512M
   engine-level limit

Therefore, we're going to experiment with a lower, 128M limit.

1: http://stackoverflow.com/questions/1493913/how-to-set-the-maximum-memory-usage-for-jvm

/cc @codeclimate/review