### PR TITLE
Configure different mass thresholds for identical & similar issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,12 @@ duplication, try raising the threshold. If you suspect that the engine isn't
 catching enough duplication, try lowering the threshold. The best setting tends
 to differ from language to language.
 
-To adjust this setting, add a `mass_threshold` key with your preferred value for
+You can set thresholds for the two different types of duplication this engine
+reports: blocks that are identical to each other, and blocks that are
+structurally similar but differ in content.
+
+To adjust these thresholds, you can add `identical_mass_threshold` and
+`similar_mass_threshold` keys with your preferred value for
 an enabled language:
 
 ```yaml
@@ -54,11 +59,15 @@ engines:
     config:
       languages:
         ruby:
-          mass_threshold: 20
+          identical_mass_threshold: 20
+          similar_mass_threshold: 30
         javascript:
 ```
 
-Note that you have the update the YAML structure under the `langauges` key to
+If you would like to use the same threshold for both identical & similar issues,
+you can just set the `mass_threshold` key.
+
+Note that you have to update the YAML structure under the `langauges` key to
 the Hash type to support extra configuration.
 
 [codeclimate]: https://codeclimate.com/dashboard

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -17,8 +17,15 @@ module CC
           file_list.files
         end
 
-        def mass_threshold
-          engine_config.mass_threshold_for(self.class::LANGUAGE) || self.class::DEFAULT_MASS_THRESHOLD
+        def mass_threshold_for_check(type)
+          case type
+          when :identical
+            engine_config.identical_mass_threshold_for(self.class::LANGUAGE) || self.class::DEFAULT_MASS_THRESHOLDS.fetch(type)
+          when :similar
+            engine_config.similar_mass_threshold_for(self.class::LANGUAGE) || self.class::DEFAULT_MASS_THRESHOLDS.fetch(type)
+          else
+            raise ArgumentError.new("#{type} is not a valid check type")
+          end
         end
 
         def base_points

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -18,12 +18,20 @@ module CC
           config.fetch("concurrency", 2)
         end
 
-        def mass_threshold_for(language)
+        def identical_mass_threshold_for(language)
           threshold = fetch_language(language).fetch("mass_threshold", nil)
 
           if threshold
             threshold.to_i
           end
+        end
+
+        def identical_mass_threshold_for(language)
+          mass_threshold_with_fallback(language, "identical_mass_threshold")
+        end
+
+        def similar_mass_threshold_for(language)
+          mass_threshold_with_fallback(language, "similar_mass_threshold")
         end
 
         def paths_for(language)
@@ -65,6 +73,15 @@ module CC
           else
             {}
           end
+        end
+
+        def mass_threshold_with_fallback(language, key)
+          language_hash = fetch_language(language)
+          threshold = language_hash.fetch(key) do |key|
+            language_hash.fetch("mass_threshold", nil)
+          end
+
+          threshold.to_i if threshold
         end
       end
     end

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -19,14 +19,6 @@ module CC
         end
 
         def identical_mass_threshold_for(language)
-          threshold = fetch_language(language).fetch("mass_threshold", nil)
-
-          if threshold
-            threshold.to_i
-          end
-        end
-
-        def identical_mass_threshold_for(language)
           mass_threshold_with_fallback(language, "identical_mass_threshold")
         end
 

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -69,7 +69,7 @@ module CC
 
         def mass_threshold_with_fallback(language, key)
           language_hash = fetch_language(language)
-          threshold = language_hash.fetch(key) do |key|
+          threshold = language_hash.fetch(key) do
             language_hash.fetch("mass_threshold", nil)
           end
 

--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -15,7 +15,7 @@ module CC
             "**/*.jsx"
           ]
           LANGUAGE = "javascript"
-          DEFAULT_MASS_THRESHOLD = 40
+          DEFAULT_MASS_THRESHOLDS = {identical: 40, similar: 80}.freeze
           BASE_POINTS = 3000
 
           private

--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -14,7 +14,7 @@ module CC
             "**/*.inc",
             "**/*.module"
           ]
-          DEFAULT_MASS_THRESHOLD = 10
+          DEFAULT_MASS_THRESHOLDS = {identical: 10, similar: 20}.freeze
           BASE_POINTS = 4_000
 
           private

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -12,7 +12,7 @@ module CC
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "python"
           DEFAULT_PATHS = ["**/*.py"]
-          DEFAULT_MASS_THRESHOLD = 40
+          DEFAULT_MASS_THRESHOLDS = {identical: 40, similar: 80}.freeze
           BASE_POINTS = 1000
 
           private

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -17,7 +17,7 @@ module CC
             "**/*.gemspec"
 
           ]
-          DEFAULT_MASS_THRESHOLD = 18
+          DEFAULT_MASS_THRESHOLDS = {identical: 18, similar: 36}.freeze
           BASE_POINTS = 10_000
           TIMEOUT = 10
 

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -70,13 +70,26 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
           }
         }
       })
-
       expect(engine_config.paths_for("elixir")).to be_nil
     end
   end
 
-  describe "mass_threshold_for" do
+  shared_examples "mass_threshold examples" do
     it "returns configured mass threshold as integer" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => {
+            "EliXiR" => {
+              specific_mass_threshold_key => "13"
+            }
+          }
+        }
+      })
+
+      expect(engine_config.send(tested_method, "elixir")).to eq(13)
+    end
+
+    it "returns fallback mass threshold as integer" do
       engine_config = CC::Engine::Analyzers::EngineConfig.new({
         "config" => {
           "languages" => {
@@ -87,7 +100,7 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
         }
       })
 
-      expect(engine_config.mass_threshold_for("elixir")).to eq(13)
+      expect(engine_config.send(tested_method, "elixir")).to eq(13)
     end
 
     it "returns nil when language is empty" do
@@ -99,7 +112,21 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
         }
       })
 
-      expect(engine_config.mass_threshold_for("ruby")).to be_nil
+      expect(engine_config.send(tested_method, "ruby")).to be_nil
+    end
+  end
+
+  describe "similar_mass_threshold_for" do
+    include_examples "mass_threshold examples" do
+      let(:specific_mass_threshold_key) { "similar_mass_threshold" }
+      let(:tested_method) { :similar_mass_threshold_for }
+    end
+  end
+
+  describe "identical_mass_threshold_for" do
+    include_examples "mass_threshold examples" do
+      let(:specific_mass_threshold_key) { "identical_mass_threshold" }
+      let(:tested_method) { :identical_mass_threshold_for }
     end
   end
 

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -61,14 +61,8 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
   end
 
   def engine_conf
-    CC::Engine::Analyzers::EngineConfig.new({
-      'config' => {
-        'languages' => {
-          'javascript' => {
-            'mass_threshold' => 1
-          }
-        }
-      }
-    })
+    CC::Engine::Analyzers::EngineConfig.new(engine_config_for_language({
+      "mass_threshold" => 1,
+    }))
   end
 end

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -56,14 +56,8 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
   end
 
   def engine_conf
-    CC::Engine::Analyzers::EngineConfig.new({
-      'config' => {
-        'languages' => {
-          'php' => {
-            'mass_threshold' => 5
-          }
-        }
-      }
-    })
+    CC::Engine::Analyzers::EngineConfig.new(engine_config_for_language({
+      "mass_threshold" => 5,
+    }))
   end
 end

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -39,14 +39,8 @@ print("Hello", "python")
   end
 
   def engine_conf
-    CC::Engine::Analyzers::EngineConfig.new({
-      "config" => {
-        "languages" => {
-          "python" => {
-            "mass_threshold" => 4
-          }
-        }
-      }
-    })
+    CC::Engine::Analyzers::EngineConfig.new(engine_config_for_language({
+      "mass_threshold" => 4,
+    }))
   end
 end

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -86,7 +86,6 @@ RSpec.describe CC::Engine::Analyzers::Ruby::Main, in_tmpdir: true do
         "similar_mass_threshold" => 20,
       }))
       result = run_engine(config).strip
-      puts "result is #{result}\n\n\n"
       json = JSON.parse(result)
 
       expect(json["check_name"]).to eq "Identical code"

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -55,9 +55,51 @@ RSpec.describe CC::Engine::Analyzers::Ruby::Main, in_tmpdir: true do
         expect(run_engine(engine_conf)).to eq("")
       }.to output(/Skipping file/).to_stderr
     end
+
+    it "respects different check type thresholds" do
+      create_source_file("foo.rb", <<-EORUBY)
+        def identical
+          puts "identical \#{thing.bar} \#{other.fun} \#{moo ? "moo" : "cluck"}"
+          puts "identical \#{thing.bar} \#{other.fun} \#{moo ? "moo" : "cluck"}"
+          puts "identical \#{thing.bar} \#{other.fun} \#{moo ? "moo" : "cluck"}"
+        end
+
+        describe 'similar1' do
+          before { subject.type = 'js' }
+
+          it 'returns true' do
+            expect(subject.ruby?).to be true
+          end
+        end
+
+        describe 'similar2' do
+          before { subject.type = 'js' }
+
+          it 'returns true' do
+            expect(subject.js?).to be true
+          end
+        end
+      EORUBY
+
+      config = CC::Engine::Analyzers::EngineConfig.new(engine_config_for_language({
+        "identical_mass_threshold" => 5,
+        "similar_mass_threshold" => 20,
+      }))
+      result = run_engine(config).strip
+      puts "result is #{result}\n\n\n"
+      json = JSON.parse(result)
+
+      expect(json["check_name"]).to eq "Identical code"
+      expect(json["location"]).to eq({
+        "path" => "foo.rb",
+        "lines" => { "begin" => 2, "end" => 2 },
+      })
+    end
   end
 
   def engine_conf
-    CC::Engine::Analyzers::EngineConfig.new({})
+    CC::Engine::Analyzers::EngineConfig.new(engine_config_for_language({
+      "mass_threshold" => described_class::DEFAULT_MASS_THRESHOLDS.fetch(:identical),
+    }))
   end
 end

--- a/spec/cc/engine/analyzers/sexp_lines_spec.rb
+++ b/spec/cc/engine/analyzers/sexp_lines_spec.rb
@@ -16,7 +16,7 @@ module CC::Engine::Analyzers
         SOURCE
         flay = Flay.new({
           diff: false,
-          mass: CC::Engine::Analyzers::Ruby::Main::DEFAULT_MASS_THRESHOLD,
+          mass: CC::Engine::Analyzers::Ruby::Main::DEFAULT_MASS_THRESHOLDS.fetch(:identical),
           summary: false,
           verbose: false,
           number: true,

--- a/spec/support/helpers/analyzer_spec_helpers.rb
+++ b/spec/support/helpers/analyzer_spec_helpers.rb
@@ -3,6 +3,16 @@ module AnalyzerSpecHelpers
     File.write(File.join(@code, path), content)
   end
 
+  def engine_config_for_language(config = {})
+    {
+      "config" => {
+        "languages" => {
+          described_class::LANGUAGE => config,
+        },
+      },
+    }
+  end
+
   def run_engine(config = nil)
     io = StringIO.new
 


### PR DESCRIPTION
One of the things I've noticed recently when running the duplication engine both against real code & just for testing is that generally when it emits issues I think are silly, it's because the the locations are structurally *similar*, but not identical. Examples of kind of silly issues this results in:

* complaining that you care calling an `attributes` macro with two completely different sets of attribute names on two separate classes (i.e. `attribute :foo, :bar, :baz` is a duplicate of `attribute :fleek, :fluck, :fark`)
* complaining that you have an if statement that calls different methods on the same objects in the branches (`if (this.someProp) { a.doThing(); b.doAlso(); } else { a.doOtherThing(); b.doOtherAlso(); }`)
* complaining that you are catching different exceptions & generating different error messages from them (see recent pr #44)

I'm of the opinion that generally speaking the bar for similar code being a violation should be higher than identical code. Particularly at relatively low masses (which our defaults all are). Complaining about things like calling methods with different arguments in different places is not just low-value, but *negative* value IMHO: it's noise that distracts from legitimate issues & makes the engine as a whole seem less reliable.

This won't completely eliminate these instances, but it will make them rarer & easier to filter out without throwing out the baby with the bathwater (the baby in this case being more severe duplication issues that are either identical blocks or bigger similar blocks). I'm also starting to think setting per-file/global levels would also be helpful: i.e. you might want a lower threshold for similar code in the same file than you do for similar code across an entire project.

Thoughts, @codeclimate/review ?