### PR TITLE
remove Java heap settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,4 @@ RUN npm install
 
 USER app
 
-ENV JAVA_OPTS="-Xms128m -Xmx128m"
-
 CMD ["/usr/src/app/bin/duplication"]


### PR DESCRIPTION
These seem to be causing non-deterministic analysis results from some
behavior in JRuby/the JVM. While we hunt this down, it would be
preferable to not set heap limits & let the engine hard-crash by hitting
container memory limits.

cc @codeclimate/review