### PR TITLE
rescue less

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -1,16 +1,27 @@
+require "cc/engine/analyzers/parser_error"
+
 module CC
   module Engine
     module Analyzers
       class Base
+        RESCUABLE_ERRORS = [
+          ::CC::Engine::Analyzers::ParserError,
+          ::Racc::ParseError,
+          ::Timeout::Error,
+        ]
+
         def initialize(engine_config:)
           @engine_config = engine_config
         end
 
         def run(file)
           process_file(file)
+        rescue *RESCUABLE_ERRORS => ex
+          $stderr.puts("Skipping file #{file} due to exception:")
+          $stderr.puts("(#{ex.class}) #{ex.message} #{ex.backtrace.join("\n")}")
         rescue => ex
-          $stderr.puts "Skipping file #{file} due to exception"
-          $stderr.puts "(#{ex.class}) #{ex.message} #{ex.backtrace.join("\n")}"
+          $stderr.puts("#{ex.class} error occurred processing file #{file}: aborting.")
+          raise ex
         end
 
         def files

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -7,7 +7,6 @@ module CC
         RESCUABLE_ERRORS = [
           ::CC::Engine::Analyzers::ParserError,
           ::Racc::ParseError,
-          ::Timeout::Error,
         ]
 
         def initialize(engine_config:)

--- a/lib/cc/engine/analyzers/command_line_runner.rb
+++ b/lib/cc/engine/analyzers/command_line_runner.rb
@@ -1,0 +1,45 @@
+require "open3"
+require "timeout"
+
+module CC
+  module Engine
+    module Analyzers
+      class CommandLineRunner
+        DEFAULT_TIMEOUT = 20
+
+        def initialize(command, timeout = DEFAULT_TIMEOUT)
+          @command = command
+          @timeout = timeout
+        end
+
+        def run(input)
+          Timeout.timeout(timeout) do
+            Open3.popen3 command, "r+" do |stdin, stdout, stderr, wait_thr|
+              stdin.puts input
+              stdin.close
+
+              exit_code = wait_thr.value
+
+              output = stdout.gets
+              stdout.close
+
+              err_output = stderr.gets
+              stderr.close
+
+              if 0 == exit_code
+                yield output
+              else
+                raise ::CC::Engine::Analyzers::ParserError, "Python parser exited with code #{exit_code}:\n#{err_output}"
+              end
+            end
+          end
+        end
+
+        private
+
+        attr_reader :command, :timeout
+      end
+    end
+  end
+end
+

--- a/lib/cc/engine/analyzers/command_line_runner.rb
+++ b/lib/cc/engine/analyzers/command_line_runner.rb
@@ -5,7 +5,7 @@ module CC
   module Engine
     module Analyzers
       class CommandLineRunner
-        DEFAULT_TIMEOUT = 20
+        DEFAULT_TIMEOUT = 300
 
         def initialize(command, timeout = DEFAULT_TIMEOUT)
           @command = command

--- a/lib/cc/engine/analyzers/javascript/parser.rb
+++ b/lib/cc/engine/analyzers/javascript/parser.rb
@@ -1,6 +1,4 @@
-require "open3"
-require "timeout"
-
+require "cc/engine/analyzers/command_line_runner"
 
 module CC
   module Engine
@@ -15,7 +13,7 @@ module CC
           end
 
           def parse
-            runner = CommandLineRunner.new(js_command, self)
+            runner = CommandLineRunner.new(js_command)
             runner.run(strip_shebang(code)) do |ast|
               json_ast = JSON.parse(ast)
               @syntax_tree = json_ast
@@ -36,45 +34,6 @@ module CC
               code.lines.drop(1).join
             else
               code
-            end
-          end
-        end
-
-        class CommandLineRunner
-          attr_reader :command, :delegate
-
-          DEFAULT_TIMEOUT = 20
-          EXCEPTIONS = [
-            StandardError,
-            Timeout::Error,
-            SystemStackError
-          ]
-
-          def initialize(command, delegate)
-            @command = command
-            @delegate = delegate
-          end
-
-          def run(input, timeout = DEFAULT_TIMEOUT)
-            Timeout.timeout(timeout) do
-              Open3.popen3 command, "r+" do |stdin, stdout, stderr, wait_thr|
-                stdin.puts input
-                stdin.close
-
-                exit_code = wait_thr.value
-
-                output = stdout.gets
-                stdout.close
-
-                err_output = stderr.gets
-                stderr.close
-
-                if 0 == exit_code
-                  yield output
-                else
-                  raise ::CC::Engine::Analyzers::ParserError, "Python parser exited with code #{exit_code}:\n#{err_output}"
-                end
-              end
             end
           end
         end

--- a/lib/cc/engine/analyzers/parser_error.rb
+++ b/lib/cc/engine/analyzers/parser_error.rb
@@ -1,0 +1,7 @@
+module CC
+  module Engine
+    module Analyzers
+      ParserError = Class.new(StandardError)
+    end
+  end
+end

--- a/lib/cc/engine/analyzers/php/parser.rb
+++ b/lib/cc/engine/analyzers/php/parser.rb
@@ -48,14 +48,23 @@ module CC
 
           def run(input, timeout = DEFAULT_TIMEOUT)
             Timeout.timeout(timeout) do
-              IO.popen command, 'r+' do |io|
-                io.puts input
-                io.close_write
+              Open3.popen3 command, "r+" do |stdin, stdout, stderr, wait_thr|
+                stdin.puts input
+                stdin.close
 
-                output = io.gets
-                io.close
+                exit_code = wait_thr.value
 
-                yield output if $?.to_i == 0
+                output = stdout.gets
+                stdout.close
+
+                err_output = stderr.gets
+                stderr.close
+
+                if 0 == exit_code
+                  yield output
+                else
+                  raise ::CC::Engine::Analyzers::ParserError, "Python parser exited with code #{exit_code}:\n#{err_output}"
+                end
               end
             end
           end

--- a/lib/cc/engine/analyzers/php/parser.rb
+++ b/lib/cc/engine/analyzers/php/parser.rb
@@ -1,5 +1,6 @@
-require 'cc/engine/analyzers/php/ast'
-require 'cc/engine/analyzers/php/nodes'
+require "cc/engine/analyzers/command_line_runner"
+require "cc/engine/analyzers/php/ast"
+require "cc/engine/analyzers/php/nodes"
 
 module CC
   module Engine
@@ -34,39 +35,6 @@ module CC
             File.expand_path(
               File.join(File.dirname(__FILE__), relative_path)
             )
-          end
-        end
-
-        class CommandLineRunner
-          attr_reader :command, :delegate
-
-          DEFAULT_TIMEOUT = 20
-
-          def initialize(command)
-            @command = command
-          end
-
-          def run(input, timeout = DEFAULT_TIMEOUT)
-            Timeout.timeout(timeout) do
-              Open3.popen3 command, "r+" do |stdin, stdout, stderr, wait_thr|
-                stdin.puts input
-                stdin.close
-
-                exit_code = wait_thr.value
-
-                output = stdout.gets
-                stdout.close
-
-                err_output = stderr.gets
-                stderr.close
-
-                if 0 == exit_code
-                  yield output
-                else
-                  raise ::CC::Engine::Analyzers::ParserError, "Python parser exited with code #{exit_code}:\n#{err_output}"
-                end
-              end
-            end
           end
         end
       end

--- a/lib/cc/engine/analyzers/python/parser.rb
+++ b/lib/cc/engine/analyzers/python/parser.rb
@@ -1,6 +1,6 @@
+require "cc/engine/analyzers/command_line_runner"
 require "timeout"
 require "json"
-require "open3"
 
 module CC
   module Engine
@@ -15,7 +15,7 @@ module CC
           end
 
           def parse
-            runner = CommandLineRunner.new(python_command, self)
+            runner = CommandLineRunner.new(python_command)
             runner.run(code) do |ast|
               json_ast = JSON.parse(ast)
               @syntax_tree = json_ast
@@ -27,40 +27,6 @@ module CC
           def python_command
             file = File.expand_path(File.dirname(__FILE__)) + '/parser.py'
             "python #{file}"
-          end
-        end
-
-        class CommandLineRunner
-          DEFAULT_TIMEOUT = 20
-
-          attr_reader :command, :delegate
-
-          def initialize(command, delegate)
-            @command = command
-            @delegate = delegate
-          end
-
-          def run(input, timeout = DEFAULT_TIMEOUT)
-            Timeout.timeout(timeout) do
-              Open3.popen3 command, "r+" do |stdin, stdout, stderr, wait_thr|
-                stdin.puts input
-                stdin.close
-
-                exit_code = wait_thr.value
-
-                output = stdout.gets
-                stdout.close
-
-                err_output = stderr.gets
-                stderr.close
-
-                if 0 == exit_code
-                  yield output
-                else
-                  raise ::CC::Engine::Analyzers::ParserError, "Python parser exited with code #{exit_code}:\n#{err_output}"
-                end
-              end
-            end
           end
         end
       end

--- a/lib/cc/engine/analyzers/python/parser.rb
+++ b/lib/cc/engine/analyzers/python/parser.rb
@@ -1,5 +1,6 @@
-require 'timeout'
-require 'json'
+require "timeout"
+require "json"
+require "open3"
 
 module CC
   module Engine
@@ -41,14 +42,23 @@ module CC
 
           def run(input, timeout = DEFAULT_TIMEOUT)
             Timeout.timeout(timeout) do
-              IO.popen command, "r+" do |io|
-                io.puts input
-                io.close_write
+              Open3.popen3 command, "r+" do |stdin, stdout, stderr, wait_thr|
+                stdin.puts input
+                stdin.close
 
-                output = io.gets
-                io.close
+                exit_code = wait_thr.value
 
-                yield output if $?.to_i == 0
+                output = stdout.gets
+                stdout.close
+
+                err_output = stderr.gets
+                stderr.close
+
+                if 0 == exit_code
+                  yield output
+                else
+                  raise ::CC::Engine::Analyzers::ParserError, "Python parser exited with code #{exit_code}:\n#{err_output}"
+                end
               end
             end
           end

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -19,7 +19,7 @@ module CC
           ]
           DEFAULT_MASS_THRESHOLD = 18
           BASE_POINTS = 10_000
-          TIMEOUT = 10
+          TIMEOUT = 300
 
           private
 

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -36,6 +36,16 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
       expect(json["content"]["body"]).to match /This issue has a mass of `99`/
       expect(json["fingerprint"]).to eq("55ae5d0990647ef496e9e0d315f9727d")
     end
+
+    it "skips unparsable files" do
+      create_source_file("foo.js", <<-EOJS)
+        function () { do(); // missing closing brace
+      EOJS
+
+      expect {
+        expect(run_engine(engine_conf)).to eq("")
+      }.to output(/Skipping file/).to_stderr
+    end
   end
 
   it "does not flag duplicate comments" do

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -48,6 +48,16 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
       expect(json["content"]["body"]).to match /This issue has a mass of `44`/
       expect(json["fingerprint"]).to eq("667da0e2bab866aa2fe9d014a65d57d9")
     end
+
+    it "skips unparsable files" do
+      create_source_file("foo.php", <<-EOPHP)
+        <?php blorb &; "fee
+      EOPHP
+
+      expect {
+        expect(run_engine(engine_conf)).to eq("")
+      }.to output(/Skipping file/).to_stderr
+    end
   end
 
   def printed_issue

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -36,6 +36,16 @@ print("Hello", "python")
       expect(json["content"]["body"]).to match /This issue has a mass of `54`/
       expect(json["fingerprint"]).to eq("42b832387c997f54a2012efb2159aefc")
     end
+
+    it "skips unparsable files" do
+      create_source_file("foo.py", <<-EOPY)
+        ---
+      EOPY
+
+      expect {
+        expect(run_engine(engine_conf)).to eq("")
+      }.to output(/Skipping file/).to_stderr
+    end
   end
 
   def engine_conf


### PR DESCRIPTION
The Analyzer `#run` loop was rescuing *all* exceptions, which is clearly
excessive. But I don't think we should hard-fail on all exceptions, either:
the Ruby parser gem is definitely known to barf on some valid but
esoteric Ruby code, and I wouldn't be surprised if the other parsers had
similar edge cases.

So this changes behavior to only skip files for a known set of catchable
errors. The out-of-process parsers are a little tricky since all you can
get from them is an exit code and output streams: for now wrapping any non-zero exit from them
in our own exception class seems reasonable. They're not effected by Java heap problems, and since we don't control the heap anymore, any potential memory problems should kill the whole container with OOM.

I'm still catching all exceptions, but only so that we can log a message
about which file is impacted before we re-raise. Since a raw exception
that will cause an abort may not contain helpful information about the file
that triggered it, this would be helpful for debugging cases.

Note that there is a similar case of an excessive `rescue` in the `FileThreadPool`. I'm investigating & fixing that separately.

Thoughts, @codeclimate/review ?