### PR TITLE
Don't rescue ThreadError in FileThreadPool

### DIFF
--- a/lib/cc/engine/analyzers/file_thread_pool.rb
+++ b/lib/cc/engine/analyzers/file_thread_pool.rb
@@ -17,11 +17,8 @@ module CC
 
           @workers = thread_count.times.map do
             Thread.new do
-              begin 
-                while item = queue.pop(true)
-                  yield item
-                end
-              rescue ThreadError
+              while !queue.empty? && (item = queue.pop(true))
+                yield item
               end
             end
           end


### PR DESCRIPTION
The previous implementation was blindly catching all ThreadError
exceptions, because that's what `#pop(true)` raises when the queue is
empty. However, there are other situations that would raise the same
class that we definitely shouldn't be silently ignoring.

This changes the code to actually check if the queue is empty before
popping, and removes the rescue entirely: if exceptions happen, we want
to know.

:eyes: @codeclimate/review