### PR TITLE
catch ENOENT

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -6,6 +6,7 @@ module CC
       class Base
         RESCUABLE_ERRORS = [
           ::CC::Engine::Analyzers::ParserError,
+          ::Errno::ENOENT,
           ::Racc::ParseError,
         ]
 


### PR DESCRIPTION
These can occur because of, for example, dangling symlinks, which are
the engine's responsibility.

:eyes: @codeclimate/review