### PR TITLE
Catch RubyParser exceptions

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -8,6 +8,7 @@ module CC
           ::CC::Engine::Analyzers::ParserError,
           ::Errno::ENOENT,
           ::Racc::ParseError,
+          ::RubyParser::SyntaxError,
         ]
 
         def initialize(engine_config:)


### PR DESCRIPTION
Depending on what causes RubyParser to fail, the exception could be from
Racc or from RubyParser, so we should catch these as well.

@codeclimate/review @abaldwinhunter