### PR TITLE
skip file message: format everything in one call

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -18,8 +18,7 @@ module CC
         def run(file)
           process_file(file)
         rescue *RESCUABLE_ERRORS => ex
-          $stderr.puts("Skipping file #{file} due to exception:")
-          $stderr.puts("(#{ex.class}) #{ex.message} #{ex.backtrace.join("\n")}")
+          $stderr.puts("Skipping file #{file} due to exception (#{ex.class}): #{ex.message}\n#{ex.backtrace.join("\n")}")
         rescue => ex
           $stderr.puts("#{ex.class} error occurred processing file #{file}: aborting.")
           raise ex


### PR DESCRIPTION
I noticed that some logs reporting skip file messages seemed to
interleave multiple messages: That's not terribly surprising due to
concurrency.

This changes the message formatting a bit & does it all in one method
call to avoid the threading issues.

@codeclimate/review