### PR TITLE
Catch RuntimeError when parsing

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -9,7 +9,8 @@ module CC
           ::Errno::ENOENT,
           ::Racc::ParseError,
           ::RubyParser::SyntaxError,
-        ]
+          ::RuntimeError,
+        ].freeze
 
         def initialize(engine_config:)
           @engine_config = engine_config


### PR DESCRIPTION
RubyParser raises `RuntimeError` instead of anything more specific in
certain parse error contexts.

Thoughts, @codeclimate/review? I don't like catching this low-level an exception, but it's pretty localized at least, so it's not the worst.

I've also reviewed the RubyParser code & haven't turned up any other likely candidates.