### PR TITLE
bump concurrent-ruby to release version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'flay', git: 'https://github.com/codeclimate/flay.git'
-gem 'concurrent-ruby', "~> 1.0.0.pre4"
+gem 'concurrent-ruby', "~> 1.0.0"
 gem 'ruby_parser'
 gem 'pry'
 gem 'sexp_processor'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.0)
-    concurrent-ruby (1.0.0.pre5)
+    concurrent-ruby (1.0.0)
     diff-lcs (1.2.5)
     json (1.8.3)
     method_source (0.8.2)
@@ -39,7 +39,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  concurrent-ruby (~> 1.0.0.pre4)
+  concurrent-ruby (~> 1.0.0)
   flay!
   json
   pry


### PR DESCRIPTION
We were on a pre-release version of this gem, and there's a stable
release now.

cc @codeclimate/review