### PR TITLE
Emit JSON errors from PHP Parser

### DIFF
--- a/vendor/php-parser/parser.php
+++ b/vendor/php-parser/parser.php
@@ -13,8 +13,13 @@ try {
 
   $serializer = new PhpParser\Serializer\JSON;
   $nodes = $serializer->serialize($stmts);
-  echo json_encode($nodes);
-
+  $json = json_encode($nodes);
+  if (false === $json) {
+    fwrite(STDERR, "Parse Error: JSON encoding failed: ".json_last_error_msg()."\n");
+    exit(1);
+  } else {
+    echo $json;
+  }
 } catch (PHPParser\Error $e) {
   fwrite(STDERR, "Parse Error: ".$e->getMessage()."\n");
   exit(1);


### PR DESCRIPTION
The PHP parser had a bug here in that it presumed JSON encoding would
succeed (and there are reasons it might not). This checks the return
value of `json_encode` and emits a relevant error message if
appropriate. Before this, a triggering case would result in empty output
and an unhelpful error message from `JSON.parse` upstream in the Ruby
code.

:eyes: @codeclimate/review 

FWIW the triggering code that led me to this was a source file that contained the string ".Inf": PHP's `encode_json` considers that to actually be a reference to the value `INF` (Infinity), which isn't a valid JSON value. I'm still looking into what the best remediation for that specific issue might be. My kingdom for a type system that doesn't boil down to "everything is either a string or a map".