### PR TITLE
PHP Parser: handle INF/NaN nodes

### DIFF
--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -56,6 +56,31 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
       expect(result).to match "\"type\":\"issue\""
     end
 
+    it "handles INF & NAN constants" do
+      create_source_file("foo.php", <<-EOPHP)
+          <?php
+          function f1($name) {
+            // the php-parser lib turns this into INF, but writing INF directly gets emitted differently
+            if (empty($name)) {
+              return 646e444;
+            } else {
+              return 0;
+            }
+          }
+
+          function f2($name) {
+            if (empty($name)) {
+              return 646e444;
+            } else {
+              return 0;
+            }
+          }
+      EOPHP
+
+      result = run_engine(engine_conf).strip
+      expect(result).to match "\"type\":\"issue\""
+    end
+
     it "skips unparsable files" do
       create_source_file("foo.php", <<-EOPHP)
         <?php blorb &; "fee

--- a/vendor/php-parser/lib/PhpParser/Serializer/JSON.php
+++ b/vendor/php-parser/lib/PhpParser/Serializer/JSON.php
@@ -29,7 +29,11 @@ class JSON implements Serializer
           }
 
           foreach ($node as $name => $subNode) {
-            if (is_string($subNode)) {
+            if (INF === $subNode) {
+              $doc[$name] = "_PHP:CONST:INF";
+            } elseif (NaN === $subNode) {
+              $doc[$name] = "_PHP:CONST:NaN";
+            } elseif (is_string($subNode)) {
               $doc[$name] = utf8_encode($subNode);
             } elseif (is_int($subNode)) {
               $doc[$name] = $subNode;


### PR DESCRIPTION
I tracked this back to this constant number in a source file.

It turns out the literal INF constant in a PHP source is fine:
the parser represents constants directly using the identifier, so
it's fine in JSON.

But the constant number is larger than PHP's max number, so it basically
overflows & get represented as INF after parsing.

On the belief that similar code might result in a NaN constant, I'm also
covering that one. This represents both values using constant strings
that are unlikely to actually appear in anyone's source code.

:eyes: @codeclimate/review