### PR TITLE
Specify similar vs identical code in description

### DIFF
--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -17,7 +17,7 @@ module CC
         def format
           {
             "type": "issue",
-            "check_name": name,
+            "check_name": check_name,
             "description": description,
             "categories": ["Duplication"],
             "location": format_location,
@@ -48,7 +48,7 @@ module CC
           @other_locations ||= sorted_hashes.drop(1)
         end
 
-        def name
+        def check_name
           if issue.identical?
             "Identical code"
           else
@@ -96,7 +96,7 @@ module CC
         end
 
         def description
-          description = "Similar code found in #{occurrences} other location"
+          description = "#{check_name} found in #{occurrences} other location"
           description += "s" if occurrences > 1
           description
         end

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
   include AnalyzerSpecHelpers
 
   describe "#run" do
-    it "prints an issue" do
+    it "prints an issue for identical code" do
       create_source_file("foo.js", <<-EOJS)
           console.log("hello JS!");
           console.log("hello JS!");
@@ -21,7 +21,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations")
+      expect(json["description"]).to eq("Identical code found in 2 other locations")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",
@@ -33,6 +33,33 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} }
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of `99`/
+      expect(json["fingerprint"]).to eq("55ae5d0990647ef496e9e0d315f9727d")
+    end
+
+    it "prints an issue for similar code" do
+      create_source_file("foo.js", <<-EOJS)
+          console.log("hello JS!");
+          console.log("hellllllo JS!");
+          console.log("helllllllllllllllllo JS!");
+      EOJS
+
+      result = run_engine(engine_conf).strip
+      json = JSON.parse(result)
+
+      expect(json["type"]).to eq("issue")
+      expect(json["check_name"]).to eq("Similar code")
+      expect(json["description"]).to eq("Similar code found in 2 other locations")
+      expect(json["categories"]).to eq(["Duplication"])
+      expect(json["location"]).to eq({
+        "path" => "foo.js",
+        "lines" => { "begin" => 1, "end" => 1 },
+      })
+      expect(json["remediation_points"]).to eq(99000)
+      expect(json["other_locations"]).to eq([
+        {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
+        {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} }
+      ])
+      expect(json["content"]["body"]).to match /This issue has a mass of `33`/
       expect(json["fingerprint"]).to eq("55ae5d0990647ef496e9e0d315f9727d")
     end
 

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
   include AnalyzerSpecHelpers
 
   describe "#run" do
-    it "prints an issue" do
+    it "prints an issue for identical code" do
       create_source_file("foo.php", <<-EOPHP)
           <?php
           function hello($name) {
@@ -34,7 +34,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Similar code found in 1 other location")
+      expect(json["description"]).to eq("Identical code found in 1 other location")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.php",

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe CC::Engine::Analyzers::Python::Main, in_tmpdir: true do
   include AnalyzerSpecHelpers
 
   describe "#run" do
-    it "prints an issue" do
+    it "prints an issue for identical code" do
       create_source_file("foo.py", <<-EOJS)
 print("Hello", "python")
 print("Hello", "python")
@@ -21,7 +21,7 @@ print("Hello", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations")
+      expect(json["description"]).to eq("Identical code found in 2 other locations")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
@@ -35,6 +35,34 @@ print("Hello", "python")
       expect(json["content"]["body"]).to match /This issue has a mass of `54`/
       expect(json["fingerprint"]).to eq("42b832387c997f54a2012efb2159aefc")
     end
+
+    it "prints an issue for similar code" do
+      create_source_file("foo.py", <<-EOJS)
+print("Hello", "python")
+print("Hello It's me", "python")
+print("Hello from the other side", "python")
+      EOJS
+
+      result = run_engine(engine_conf).strip
+      json = JSON.parse(result)
+
+      expect(json["type"]).to eq("issue")
+      expect(json["check_name"]).to eq("Similar code")
+      expect(json["description"]).to eq("Similar code found in 2 other locations")
+      expect(json["categories"]).to eq(["Duplication"])
+      expect(json["location"]).to eq({
+        "path" => "foo.py",
+        "lines" => { "begin" => 1, "end" => 1 },
+      })
+      expect(json["remediation_points"]).to eq(18000)
+      expect(json["other_locations"]).to eq([
+        {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
+        {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} }
+      ])
+      expect(json["content"]["body"]).to match /This issue has a mass of `18`/
+      expect(json["fingerprint"]).to eq("42b832387c997f54a2012efb2159aefc")
+    end
+
 
     it "skips unparsable files" do
       create_source_file("foo.py", <<-EOPY)


### PR DESCRIPTION
This information is already present on issue check_name, but the description is more visible.
@codeclimate/review 

![image](https://cloud.githubusercontent.com/assets/8718443/12365580/b0571524-bba3-11e5-8837-e3fd4619cc14.png)
