### PR TITLE
include mass in description

### DIFF
--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -98,7 +98,7 @@ module CC
         def description
           description = "#{check_name} found in #{occurrences} other location"
           description += "s" if occurrences > 1
-          description
+          description += " (mass = #{issue.mass})"
         end
 
         def occurrences

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 2 other locations")
+      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 99)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",
@@ -48,7 +48,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations")
+      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 33)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -91,11 +91,6 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
     end
   end
 
-  def printed_issue
-    issue = {"type":"issue","check_name":"Identical code","description":"Similar code found in 1 other location","categories":["Duplication"],"location":{"path":"foo.php","lines":{"begin":2,"end":6}},"remediation_points":176000,"other_locations":[{"path":"foo.php","lines":{"begin":10,"end":14}}],"content":{"body": read_up}}
-    issue.to_json + "\0\n"
-  end
-
   def engine_conf
     CC::Engine::Analyzers::EngineConfig.new({
       'config' => {

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 1 other location")
+      expect(json["description"]).to eq("Identical code found in 1 other location (mass = 44)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.php",

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -21,7 +21,7 @@ print("Hello", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 2 other locations")
+      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 54)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
@@ -48,7 +48,7 @@ print("Hello from the other side", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations")
+      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 18)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -33,7 +33,7 @@ module CC::Engine::Analyzers
 
         expect(json["type"]).to eq("issue")
         expect(json["check_name"]).to eq("Similar code")
-        expect(json["description"]).to eq("Similar code found in 1 other location")
+        expect(json["description"]).to eq("Similar code found in 1 other location (mass = 36)")
         expect(json["categories"]).to eq(["Duplication"])
         expect(json["location"]).to eq({
           "path" => "foo.rb",


### PR DESCRIPTION
- Increase parity with Code Climate classic duplication reporting
- Make mass more salient

The mass is already presented in the issue content readup, but
it's lost in a sea of non-custom text.

Classic:

![screen shot 2016-01-15 at 6 40 58 pm](https://cloud.githubusercontent.com/assets/8718443/12368253/9969f7aa-bbb7-11e5-89da-4ac2eedebb48.png)

@codeclimate/review 