### PR TITLE
Tune python duplication remediation points

### DIFF
--- a/config/contents/duplicated_code.md.erb
+++ b/config/contents/duplicated_code.md.erb
@@ -9,7 +9,7 @@ When you violate DRY, bugs and maintenance problems are sure to follow. Duplicat
 ## Issue Mass
 
 Duplicated code has a calculated mass, which can be thought of as a measure of how much logic has been duplicated.
-This issue has a mass of `<%= issue.mass %>`: if you would like to change the minimum mass that will be reported as an issue, please see the details in [`codeclimate-duplication`'s documentation](https://github.com/codeclimate/codeclimate-duplication).
+This issue has a mass of `<%= mass %>`: if you would like to change the minimum mass that will be reported as an issue, please see the details in [`codeclimate-duplication`'s documentation](https://github.com/codeclimate/codeclimate-duplication).
 
 ## Refactorings
 

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -36,8 +36,8 @@ module CC
           engine_config.mass_threshold_for(self.class::LANGUAGE) || self.class::DEFAULT_MASS_THRESHOLD
         end
 
-        def calculate_points(issue)
-          self.class::BASE_POINTS * issue.mass
+        def calculate_points(mass)
+          self.class::BASE_POINTS * mass
         end
 
         private

--- a/lib/cc/engine/analyzers/issue.rb
+++ b/lib/cc/engine/analyzers/issue.rb
@@ -1,0 +1,89 @@
+require "cc/engine/analyzers/sexp_lines"
+require "cc/engine/analyzers/violation_read_up"
+require "digest"
+
+module CC
+  module Engine
+    module Analyzers
+      class Issue
+        def initialize(language_strategy:, check_name:, current_sexp:, other_sexps:)
+          @language_strategy = language_strategy
+          @check_name = check_name
+          @current_sexp = current_sexp
+          @other_sexps = other_sexps
+        end
+
+        def format # rubocop:disable Metrics/MethodLength
+          {
+            "type": "issue",
+            "check_name": check_name,
+            "description": description,
+            "categories": ["Duplication"],
+            "location": format_location,
+            "remediation_points": calculate_points,
+            "other_locations": format_other_locations,
+            "content": content_body,
+            "fingerprint": fingerprint,
+          }
+        end # rubocop:enable Metrics/MethodLength
+
+        def report_name
+          "#{current_sexp.file}-#{current_sexp.line}"
+        end
+
+        def mass
+          current_sexp.mass
+        end
+
+        private
+
+        attr_reader :language_strategy, :check_name, :other_sexps, :current_sexp
+
+        def calculate_points
+          language_strategy.calculate_points(mass)
+        end
+
+        def format_location
+          format_sexp(current_sexp)
+        end
+
+        def format_other_locations
+          other_sexps.map do |sexp|
+            format_sexp(sexp)
+          end
+        end
+
+        def format_sexp(sexp)
+          lines = SexpLines.new(sexp)
+          {
+            "path": sexp.file.gsub(%r{^./}, ""),
+            "lines": {
+              "begin": lines.begin_line,
+              "end": lines.end_line,
+            },
+          }
+        end
+
+        def content_body
+          { "body": ViolationReadUp.new(mass).contents }
+        end
+
+        def fingerprint
+          digest = Digest::MD5.new
+          digest << current_sexp.file
+          digest << "-"
+          digest << current_sexp.mass.to_s
+          digest << "-"
+          digest << check_name
+          digest.to_s
+        end
+
+        def description
+          description = "#{check_name} found in #{(other_sexps.length)} other location"
+          description += "s" if other_sexps.length > 1
+          description
+        end
+      end
+    end
+  end
+end

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -12,10 +12,19 @@ module CC
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "python"
           DEFAULT_PATHS = ["**/*.py"]
-          DEFAULT_MASS_THRESHOLD = 40
-          BASE_POINTS = 1000
+          DEFAULT_MASS_THRESHOLD = 32
+          BASE_POINTS = 1_500_000
+          POINTS_PER_OVERAGE = 50_000
+
+          def calculate_points(mass)
+            BASE_POINTS + (overage(mass) * POINTS_PER_OVERAGE)
+          end
 
           private
+
+          def overage(mass)
+            mass - mass_threshold
+          end
 
           def process_file(path)
             Node.new(::CC::Engine::Analyzers::Python::Parser.new(File.binread(path), path).parse.syntax_tree, path).format

--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -38,9 +38,11 @@ module CC
           flay.report(StringIO.new).each do |issue|
             violation = new_violation(issue)
 
-            unless reports.include?(violation.report_name)
-              reports.add(violation.report_name)
-              io.puts "#{violation.format.to_json}\0"
+            violation.occurrences.each do |occurrence|
+              unless reports.include?(occurrence.report_name)
+                reports.add(occurrence.report_name)
+                io.puts "#{occurrence.format.to_json}\0"
+              end
             end
           end
         end

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -22,14 +22,14 @@ module CC
           POINTS_PER_OVERAGE = 100_000
           TIMEOUT = 300
 
-          def calculate_points(issue)
-            BASE_POINTS + (overage(issue) * POINTS_PER_OVERAGE)
+          def calculate_points(mass)
+            BASE_POINTS + (overage(mass) * POINTS_PER_OVERAGE)
           end
 
           private
 
-          def overage(issue)
-            issue.mass - mass_threshold
+          def overage(mass)
+            mass - mass_threshold
           end
 
           def process_file(file)

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -1,52 +1,24 @@
-require "cc/engine/analyzers/sexp_lines"
-require "cc/engine/analyzers/violation_read_up"
-require "digest"
+require "cc/engine/analyzers/issue"
 
 module CC
   module Engine
     module Analyzers
       class Violation
-        attr_reader :issue
-
         def initialize(language_strategy, issue, hashes)
           @language_strategy = language_strategy
-          @issue = issue
           @hashes = hashes
+          @issue = issue
         end
 
-        def format
-          {
-            "type": "issue",
-            "check_name": check_name,
-            "description": description,
-            "categories": ["Duplication"],
-            "location": format_location,
-            "remediation_points": calculate_points,
-            "other_locations": format_other_locations,
-            "content": content_body,
-            "fingerprint": fingerprint
-          }
-        end
-
-        def report_name
-          "#{current_sexp.file}-#{current_sexp.line}"
+        def occurrences
+          hashes.map.with_index do |sexp, i|
+            Issue.new(language_strategy: language_strategy, check_name: check_name, current_sexp: sexp, other_sexps: other_sexps(hashes.dup, i))
+          end
         end
 
         private
 
-        attr_reader :language_strategy, :hashes
-
-        def current_sexp
-          @location ||= sorted_hashes.first
-        end
-
-        def sorted_hashes
-          @_sorted_hashes ||= hashes.sort_by(&:file)
-        end
-
-        def other_sexps
-          @other_locations ||= sorted_hashes.drop(1)
-        end
+        attr_reader :language_strategy, :hashes, :issue
 
         def check_name
           if issue.identical?
@@ -56,53 +28,9 @@ module CC
           end
         end
 
-        def calculate_points
-          language_strategy.calculate_points(issue)
-        end
-
-        def format_location
-          format_sexp(current_sexp)
-        end
-
-        def format_other_locations
-          other_sexps.map do |sexp|
-            format_sexp(sexp)
-          end
-        end
-
-        def format_sexp(sexp)
-          lines = SexpLines.new(sexp)
-          {
-            "path": sexp.file.gsub(%r(^./), ""),
-            "lines": {
-              "begin": lines.begin_line,
-              "end": lines.end_line,
-            },
-          }
-        end
-
-        def content_body
-          @_content_body ||= { "body": ViolationReadUp.new(issue).contents }
-        end
-
-        def fingerprint
-          digest = Digest::MD5.new
-          digest << current_sexp.file
-          digest << "-"
-          digest << current_sexp.mass.to_s
-          digest << "-"
-          digest << occurrences.to_s
-          digest.to_s
-        end
-
-        def description
-          description = "#{check_name} found in #{occurrences} other location"
-          description += "s" if occurrences > 1
-          description
-        end
-
-        def occurrences
-          other_sexps.count
+        def other_sexps(members, i)
+          members.delete_at(i)
+          members.sort_by(&:file)
         end
       end
     end

--- a/lib/cc/engine/analyzers/violation_read_up.rb
+++ b/lib/cc/engine/analyzers/violation_read_up.rb
@@ -4,8 +4,8 @@ module CC
   module Engine
     module Analyzers
       class ViolationReadUp
-        def initialize(issue)
-          @issue = issue
+        def initialize(mass)
+          @mass = mass
         end
 
         def contents
@@ -14,7 +14,7 @@ module CC
 
         private
 
-        attr_reader :issue
+        attr_reader :mass
 
         TEMPLATE_REL_PATH = "../../../../config/contents/duplicated_code.md.erb"
 

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -1,9 +1,8 @@
+require 'spec_helper'
 require 'cc/engine/analyzers/javascript/main'
 require 'cc/engine/analyzers/reporter'
 require 'cc/engine/analyzers/engine_config'
 require 'cc/engine/analyzers/file_list'
-require 'flay'
-require 'tmpdir'
 
 RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
   include AnalyzerSpecHelpers
@@ -16,7 +15,9 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
           console.log("hello JS!");
       EOJS
 
-      result = run_engine(engine_conf).strip
+      issues = run_engine(engine_conf).strip.split("\0")
+      result = issues.first.strip
+
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
@@ -27,13 +28,13 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(297000)
+      expect(json["remediation_points"]).to eq(33_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} }
       ])
-      expect(json["content"]["body"]).to match /This issue has a mass of `99`/
-      expect(json["fingerprint"]).to eq("55ae5d0990647ef496e9e0d315f9727d")
+      expect(json["content"]["body"]).to match /This issue has a mass of `11`/
+      expect(json["fingerprint"]).to eq("c4d29200c20d02297c6f550ad2c87c15")
     end
 
     it "prints an issue for similar code" do
@@ -43,7 +44,9 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
           console.log("helllllllllllllllllo JS!");
       EOJS
 
-      result = run_engine(engine_conf).strip
+      issues = run_engine(engine_conf).strip.split("\0")
+      result = issues.first.strip
+
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
@@ -54,13 +57,13 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(99000)
+      expect(json["remediation_points"]).to eq(33_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} }
       ])
-      expect(json["content"]["body"]).to match /This issue has a mass of `33`/
-      expect(json["fingerprint"]).to eq("55ae5d0990647ef496e9e0d315f9727d")
+      expect(json["content"]["body"]).to match /This issue has a mass of `11`/
+      expect(json["fingerprint"]).to eq("d9dab8e4607e2a74da3b9eefb49eacec")
     end
 
     it "skips unparsable files" do
@@ -91,8 +94,8 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
           <a className='button button-primary full' href='#' onClick={this.onSubmit.bind(this)}>Login</a>
     EOJSX
 
-    result = run_engine(engine_conf).strip
-    issues = result.split("\0")
+    issues = run_engine(engine_conf).strip.split("\0")
+
     expect(issues.length).to eq 1
   end
 

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -1,9 +1,7 @@
-require "spec_helper"
-require "cc/engine/analyzers/python/main"
+require 'spec_helper'
+require 'cc/engine/analyzers/python/main'
 require 'cc/engine/analyzers/engine_config'
 require 'cc/engine/analyzers/file_list'
-require "flay"
-require "tmpdir"
 
 RSpec.describe CC::Engine::Analyzers::Python::Main, in_tmpdir: true do
   include AnalyzerSpecHelpers
@@ -16,7 +14,9 @@ print("Hello", "python")
 print("Hello", "python")
       EOJS
 
-      result = run_engine(engine_conf).strip
+      issues = run_engine(engine_conf).strip.split("\0")
+      result = issues.first.strip
+
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
@@ -27,13 +27,13 @@ print("Hello", "python")
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(54000)
+      expect(json["remediation_points"]).to eq(1_600_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} }
       ])
-      expect(json["content"]["body"]).to match /This issue has a mass of `54`/
-      expect(json["fingerprint"]).to eq("42b832387c997f54a2012efb2159aefc")
+      expect(json["content"]["body"]).to match /This issue has a mass of `6`/
+      expect(json["fingerprint"]).to eq("3f3d34361bcaef98839d9da6ca9fcee4")
     end
 
     it "prints an issue for similar code" do
@@ -43,7 +43,9 @@ print("Hello It's me", "python")
 print("Hello from the other side", "python")
       EOJS
 
-      result = run_engine(engine_conf).strip
+      issues = run_engine(engine_conf).strip.split("\0")
+      result = issues.first.strip
+
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
@@ -54,13 +56,13 @@ print("Hello from the other side", "python")
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(18000)
+      expect(json["remediation_points"]).to eq(1_600_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} }
       ])
-      expect(json["content"]["body"]).to match /This issue has a mass of `18`/
-      expect(json["fingerprint"]).to eq("42b832387c997f54a2012efb2159aefc")
+      expect(json["content"]["body"]).to match /This issue has a mass of `6`/
+      expect(json["fingerprint"]).to eq("019118ceed60bf40b35aad581aae1b02")
     end
 
 

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -1,8 +1,7 @@
+require 'spec_helper'
 require 'cc/engine/analyzers/ruby/main'
 require 'cc/engine/analyzers/engine_config'
 require 'cc/engine/analyzers/file_list'
-require 'flay'
-require 'tmpdir'
 
 module CC::Engine::Analyzers
   RSpec.describe Ruby::Main, in_tmpdir: true do
@@ -28,7 +27,9 @@ module CC::Engine::Analyzers
             end
         EORUBY
 
-        result = run_engine(engine_conf).strip
+        issues = run_engine(engine_conf).strip.split("\0")
+        result = issues.first.strip
+
         json = JSON.parse(result)
 
         expect(json["type"]).to eq("issue")
@@ -39,12 +40,44 @@ module CC::Engine::Analyzers
           "path" => "foo.rb",
           "lines" => { "begin" => 1, "end" => 5 },
         })
-        expect(json["remediation_points"]).to eq(3300000)
+        expect(json["remediation_points"]).to eq(1_500_000)
         expect(json["other_locations"]).to eq([
           {"path" => "foo.rb", "lines" => { "begin" => 9, "end" => 13} },
         ])
-        expect(json["content"]["body"]).to match /This issue has a mass of `36`/
-        expect(json["fingerprint"]).to eq("f21b75bbd135ec3ae6638364d5c73762")
+        expect(json["content"]["body"]).to match /This issue has a mass of `18`/
+        expect(json["fingerprint"]).to eq("b7e46d8f5164922678e48942e26100f2")
+      end
+
+      it "creates an issue for each occurrence of the duplicated code" do
+        create_source_file("foo.rb", <<-EORUBY)
+            describe '#ruby?' do
+              before { subject.type = 'ruby' }
+
+              it 'returns true' do
+                expect(subject.ruby?).to be true
+              end
+            end
+
+            describe '#js?' do
+              before { subject.type = 'js' }
+
+              it 'returns true' do
+                expect(subject.js?).to be true
+              end
+            end
+
+            describe '#whaddup?' do
+              before { subject.type = 'js' }
+
+              it 'returns true' do
+                expect(subject.js?).to be true
+              end
+            end
+        EORUBY
+
+        issues = run_engine(engine_conf).strip.split("\0")
+
+        expect(issues.length).to eq(3)
       end
 
       it "skips unparsable files" do
@@ -58,43 +91,43 @@ module CC::Engine::Analyzers
       end
     end
 
-    describe "#calculate_points(issue)" do
+    describe "#calculate_points(mass)" do
       let(:analyzer) { Ruby::Main.new(engine_config: engine_conf) }
       let(:base_points) { Ruby::Main::BASE_POINTS }
       let(:points_per) { Ruby::Main::POINTS_PER_OVERAGE }
       let(:threshold) { Ruby::Main::DEFAULT_MASS_THRESHOLD }
 
-      context "when issue mass exceeds threshold" do
+      context "when mass exceeds threshold" do
         it "calculates mass overage points" do
-          issue = double(:issue, mass: threshold + 10)
-          overage = issue.mass - threshold
+          mass = threshold + 10
+          overage = mass - threshold
 
           expected_points = base_points + overage * points_per
-          points = analyzer.calculate_points(issue)
+          points = analyzer.calculate_points(mass)
 
           expect(points).to eq(expected_points)
         end
       end
 
-      context "when issue mass is less than threshold" do
+      context "when mass is less than threshold" do
         it "calculates mass overage points" do
-          issue = double(:issue, mass: threshold - 5)
-          overage = issue.mass - threshold
+          mass = threshold - 5
+          overage = mass - threshold
 
           expected_points = base_points + overage * points_per
-          points = analyzer.calculate_points(issue)
+          points = analyzer.calculate_points(mass)
 
           expect(points).to eq(expected_points)
         end
       end
 
-      context "when issue mass equals threshold" do
+      context "when mass equals threshold" do
         it "calculates mass overage points" do
-          issue = double(:issue, mass: threshold)
-          overage = issue.mass - threshold
+          mass = threshold
+          overage = mass - threshold
 
           expected_points = base_points + overage * points_per
-          points = analyzer.calculate_points(issue)
+          points = analyzer.calculate_points(mass)
 
           expect(points).to eq(expected_points)
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,7 @@
 require 'bundler/setup'
+require 'flay'
 require 'tmpdir'
+
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
 


### PR DESCRIPTION
- Reduce AST threshold from 40 to ~~31~~ 32 (classic is 28)
- update point formula to match classic computation

Change from
     `remediations_points = n * score`
to
    `remediation_points = x + (score-threshold) * y`

This change increases parity with classic and overall increases the number of duplication issues reported.

[link to grade comparisons](https://gist.github.com/ABaldwinHunter/e280310b4987766efd8c)

**Note**: @GordonDiggs and I are exploring exactly why there are parser differences between Classic and Platform - there are a number of relevant factors, including likely differences between versions of Python. 

Note on mass difference:

The mass of node corresponds to its size. Specifying a minimum threshold tells Code Climate to ignore duplication in nodes below a certain size (e.g. one liners).

The issue's Flay score is the result of its **mass** * **number of occurrences** (or number of occurrences ^ 2, if the code is identical).

Comparing issue **mass** between parser in Platform and Classic:

| Platform  | Classic |  Platform / Classic    |
------------ | --------------- | ------------
 42      |  39   |  1.07
 45      |  40   |  1.125
 66      |  57   |  1.15789
 123      |  109  | 1.1284
  126    |  93  | 1.3548
  246      |  218  | 1.1284

I've estimated the factor of mass difference to be ~ 1.15
Since the default Python duplication mass threshold on Classic was 28, and  `28 * 1.15 = 32.19999`, I've lowered our current default threshold for Python on Platform from 40 to 32.

On Classic, Python duplication issues were penalized in terms of remediation points as follows:

`1_500_000 + overage * 50_000`
where overage = **score** - **threshold**
( and score = f(mass) ) 

I've kept the base points but lowered the per_cost to 30_000 to account for the difference in mass parsing (which gets amplified in the points calculation. 

@codeclimate/review 
