### PR TITLE
Install npm as part of docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY vendor/php-parser/composer.json /usr/src/app/vendor/php-parser/
 COPY vendor/php-parser/composer.lock /usr/src/app/vendor/php-parser/
 
 RUN curl --silent --location https://deb.nodesource.com/setup_5.x | bash -
-RUN apt-get update && apt-get install -y nodejs python openssh-client php5-cli php5-json
+RUN apt-get update && apt-get install -y nodejs npm python openssh-client php5-cli php5-json
 RUN gem install bundler --no-ri --no-rdoc && \
     bundle install -j 4 && \
     curl -sS https://getcomposer.org/installer | php

--- a/circle.yml
+++ b/circle.yml
@@ -11,7 +11,7 @@ machine:
 dependencies:
   override:
     - docker info
-    - docker build -t=$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
+    - docker build --rm -t=$PRIVATE_REGISTRY/$CIRCLE_PROJECT_REPONAME:b$CIRCLE_BUILD_NUM .
 
 test:
   override:


### PR DESCRIPTION
@codeclimate/review 

Fixes the following error I began seeing locally:

```
Removing intermediate container 85df8e8d7b2e
Step 14 : RUN npm install
 ---> Running in 1b4d48c42a57
/bin/sh: 1: npm: not found
```