### PR TITLE
dockerfile update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ COPY Gemfile.lock /usr/src/app/
 COPY vendor/php-parser/composer.json /usr/src/app/vendor/php-parser/
 COPY vendor/php-parser/composer.lock /usr/src/app/vendor/php-parser/
 
-RUN curl --silent --location https://deb.nodesource.com/setup_5.x | bash -
-RUN apt-get update && apt-get install -y nodejs python openssh-client php5-cli php5-json
+RUN curl --silent --location https://deb.nodesource.com/setup_5.x | bash - && \
+    apt-get update && apt-get install -y nodejs python openssh-client php5-cli php5-json
 RUN gem install bundler --no-ri --no-rdoc && \
     bundle install -j 4 && \
     curl -sS https://getcomposer.org/installer | php

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "codeclimate-duplication",
   "version": "0.0.1",
   "description": "Find similar structures in your code",
-  "license": "TODO Add actual license",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git@github.com:codeclimate/codeclimate-duplication.git"


### PR DESCRIPTION
Combine node install commands into single RUN

Avoids problematic behavior that occurs when the nodesource curl and
nodejs install commands are cached separately.

Following up on suggestion from https://github.com/codeclimate/codeclimate-duplication/pull/80/files#r50307883

@codeclimate/review 