### PR TITLE
Link to docs instead of github repo

### DIFF
--- a/config/contents/duplicated_code.md.erb
+++ b/config/contents/duplicated_code.md.erb
@@ -9,7 +9,7 @@ When you violate DRY, bugs and maintenance problems are sure to follow. Duplicat
 ## Issue Mass
 
 Duplicated code has a calculated mass, which can be thought of as a measure of how much logic has been duplicated.
-This issue has a mass of `<%= mass %>`: if you would like to change the minimum mass that will be reported as an issue, please see the details in [`codeclimate-duplication`'s documentation](https://github.com/codeclimate/codeclimate-duplication).
+This issue has a mass of `<%= mass %>`: if you would like to change the minimum mass that will be reported as an issue, please see the details in [`codeclimate-duplication`'s documentation](https://docs.codeclimate.com/docs/duplication).
 
 ## Refactorings
 


### PR DESCRIPTION
Now that we have more robust duplication docs, we can
link to them.

@codeclimate/review 