### PR TITLE
Tune Python Remediation Points

### DIFF
--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -12,10 +12,19 @@ module CC
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "python"
           DEFAULT_PATHS = ["**/*.py"]
-          DEFAULT_MASS_THRESHOLD = 40
-          BASE_POINTS = 1000
+          DEFAULT_MASS_THRESHOLD = 32
+          BASE_POINTS = 1_500_000
+          POINTS_PER_OVERAGE = 50_000
+
+          def calculate_points(mass)
+            BASE_POINTS + (overage(mass) * POINTS_PER_OVERAGE)
+          end
 
           private
+
+          def overage(mass)
+            mass - mass_threshold
+          end
 
           def process_file(path)
             Node.new(::CC::Engine::Analyzers::Python::Parser.new(File.binread(path), path).parse.syntax_tree, path).format

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -28,7 +28,7 @@ print("Hello", "python")
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(6_000)
+      expect(json["remediation_points"]).to eq(1_600_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} }
@@ -56,7 +56,7 @@ print("Hello from the other side", "python")
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(6_000)
+      expect(json["remediation_points"]).to eq(1_600_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} }


### PR DESCRIPTION
- Reduce AST threshold from 40 to 32 (classic is 28)
- update point formula to match classic computation

Change from
     remediations_points = 1000 * mass
to
     remediation_points = 1_000_000 + (mass - threshold)  * 50_000


@codeclimate/review 

Third starfish leg of https://github.com/codeclimate/codeclimate-duplication/pull/78/files