### PR TITLE
Include mass in issue description

### DIFF
--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -93,6 +93,7 @@ module CC
         def description
           description = "#{check_name} found in #{occurrences} other location"
           description += "s" if occurrences > 1
+          description += " (mass = #{mass})"
           description
         end
 

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 2 other locations")
+      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 11)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",
@@ -50,7 +50,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations")
+      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 11)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 1 other location")
+      expect(json["description"]).to eq("Identical code found in 1 other location (mass = 11)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.php",

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -22,7 +22,7 @@ print("Hello", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 2 other locations")
+      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 6)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
@@ -50,7 +50,7 @@ print("Hello from the other side", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations")
+      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 6)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -34,7 +34,7 @@ module CC::Engine::Analyzers
 
         expect(json["type"]).to eq("issue")
         expect(json["check_name"]).to eq("Similar code")
-        expect(json["description"]).to eq("Similar code found in 1 other location")
+        expect(json["description"]).to eq("Similar code found in 1 other location (mass = 18)")
         expect(json["categories"]).to eq(["Duplication"])
         expect(json["location"]).to eq({
           "path" => "foo.rb",

--- a/spec/cc/engine/analyzers/violations_spec.rb
+++ b/spec/cc/engine/analyzers/violations_spec.rb
@@ -35,7 +35,7 @@ module CC::Engine::Analyzers
 
         expect(first_formatted[:type]).to eq("issue")
         expect(first_formatted[:check_name]).to eq("Identical code")
-        expect(first_formatted[:description]).to eq("Identical code found in 2 other locations")
+        expect(first_formatted[:description]).to eq("Identical code found in 2 other locations (mass = 18)")
         expect(first_formatted[:categories]).to eq(["Duplication"])
         expect(first_formatted[:remediation_points]).to eq(30)
         expect(first_formatted[:location]).to eq({:path=>"file.rb", :lines=>{:begin=>1, :end=>5}})


### PR DESCRIPTION
- Increase mass visibility
- Increase parity with Code Climate classic duplication reporting

The mass is already presented in the issue content readup, but somewhat obfuscated.

@codeclimate/review 

Replaces https://github.com/codeclimate/codeclimate-duplication/pull/77/commits

