### PR TITLE
Revert "Include erb files for analysis, following Flay"

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,8 +8,6 @@ engines:
     enabled: true
   duplication:
     enabled: true
-    exclude_fingerprints:
-    - b2dc8dbd27916d8321e298f59fc2f431 # Erubis < ::Erubis::Eruby
     config:
       languages:
       - ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
 
-gem 'erubis'
 gem 'flay', git: 'https://github.com/codeclimate/flay.git'
 gem 'concurrent-ruby', "~> 1.0.0"
 gem 'ruby_parser'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,6 @@ GEM
     coderay (1.1.0)
     concurrent-ruby (1.0.0)
     diff-lcs (1.2.5)
-    erubis (2.7.0)
     json (1.8.3)
     method_source (0.8.2)
     pry (0.10.3)
@@ -41,7 +40,6 @@ PLATFORMS
 
 DEPENDENCIES
   concurrent-ruby (~> 1.0.0)
-  erubis
   flay!
   json
   pry

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -1,4 +1,3 @@
-require "erubis"
 require "flay"
 require "json"
 require "cc/engine/analyzers/reporter"
@@ -11,12 +10,12 @@ module CC
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "ruby"
           DEFAULT_PATHS = [
-            "**/*.erb",
             "**/*.rb",
             "**/*.rake",
             "**/Rakefile",
             "**/Gemfile",
             "**/*.gemspec"
+
           ]
           DEFAULT_MASS_THRESHOLD = 18
           BASE_POINTS = 1_500_000
@@ -34,37 +33,7 @@ module CC
           end
 
           def process_file(file)
-            if File.extname(file) == ".erb"
-              process_erb file
-            else
-              RubyParser.new.process(File.binread(file), file, TIMEOUT)
-            end
-          end
-
-          def process_erb(file)
-            erb = File.binread(file)
-            ruby = Erubis.new(erb).src
-            RubyParser.new.process(ruby, file)
-          end
-
-          class Erubis < ::Erubis::Eruby
-            BLOCK_EXPR = /\s+(do|\{)(\s*\|[^|]*\|)?\s*\Z/
-
-            def add_expr_literal(src, code)
-              if code =~ BLOCK_EXPR
-                src << "@output_buffer.append= " << code
-              else
-                src << "@output_buffer.append=(" << code << ");"
-              end
-            end
-
-            def add_expr_escaped(src, code)
-              if code =~ BLOCK_EXPR
-                src << "@output_buffer.safe_append= " << code
-              else
-                src << "@output_buffer.safe_append=(" << code << ");"
-              end
-            end
+            RubyParser.new.process(File.binread(file), file, TIMEOUT)
           end
         end
       end

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -3,7 +3,6 @@ require 'cc/engine/analyzers/javascript/main'
 require 'cc/engine/analyzers/reporter'
 require 'cc/engine/analyzers/engine_config'
 require 'cc/engine/analyzers/file_list'
-require 'erubis'
 
 RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
   include AnalyzerSpecHelpers

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -88,45 +88,6 @@ module CC::Engine::Analyzers
           expect(run_engine(engine_conf)).to eq("")
         }.to output(/Skipping file/).to_stderr
       end
-
-      it "analyzes erb files" do
-        create_source_file("recipe.erb", <<-EOERB)
-<div class="container">
-  <h1>Select a Category</h1>
-  <ul>
-  <%categories.each do |category| %>
-  <li> <a href= "/category/<%=category.id%>"><%=category.name%> | <%=category.recipes.count%> Recipes </a></li>
-  <%end%>
-
-  <%categories.each do |category| %>
-    <li> <a href= "/category/<%=category.id%>"><%=category.name%> | <%=category.recipes.count%> Recipes </a></li>
-  <%end%>
-
-  <%categories.each do |category| %>
-    <li> <a href= "/category/<%=category.id%>"><%=category.name%> | <%=category.recipes.count%> Recipes </a></li>
-  <%end%>
-</ul>
-</div>
-        EOERB
-
-        issues = run_engine(engine_conf).strip.split("\0")
-        result = issues.first.strip
-        json = JSON.parse(result)
-
-        expect(json["type"]).to eq("issue")
-        expect(json["check_name"]).to eq("Similar code")
-        expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 30)")
-        expect(json["categories"]).to eq(["Duplication"])
-        expect(json["location"]).to eq({
-          "path" => "recipe.erb",
-          "lines" => { "begin" => 4, "end" => 5 },
-        })
-        expect(json["remediation_points"]).to eq(2_700_000)
-        expect(json["other_locations"]).to eq([
-          {"path" => "recipe.erb", "lines" => { "begin" => 8, "end" => 9} },
-          {"path" => "recipe.erb", "lines" => { "begin" => 12, "end" => 13} }
-         ])
-      end
     end
 
     describe "#calculate_points(mass)" do


### PR DESCRIPTION
This reverts commit 620f2dd8e412a84de2857d8ed3596ff2fe395c88.

Roll back functionality in favor of allowing for additional
consideration about configuration/threshold options and tuning
impact on analysis.

@codeclimate/review @noahd1 