### PR TITLE
Fix fingerprint bug - don't use num occurrences

### DIFF
--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -86,7 +86,7 @@ module CC
           digest << "-"
           digest << current_sexp.mass.to_s
           digest << "-"
-          digest << occurrences.to_s
+          digest << check_name
           digest.to_s
         end
 

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} }
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of `11`/
-      expect(json["fingerprint"]).to eq("55ae5d0990647ef496e9e0d315f9727d")
+      expect(json["fingerprint"]).to eq("c4d29200c20d02297c6f550ad2c87c15")
     end
 
     it "prints an issue for similar code" do
@@ -62,7 +62,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} }
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of `11`/
-      expect(json["fingerprint"]).to eq("55ae5d0990647ef496e9e0d315f9727d")
+      expect(json["fingerprint"]).to eq("d9dab8e4607e2a74da3b9eefb49eacec")
     end
 
     it "skips unparsable files" do

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
         {"path" => "foo.php", "lines" => { "begin" => 10, "end" => 14} },
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of `11`/
-      expect(json["fingerprint"]).to eq("667da0e2bab866aa2fe9d014a65d57d9")
+      expect(json["fingerprint"]).to eq("8234e10d96fd6ef608085c22c91c9ab1")
     end
 
     it "runs against complex files" do

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -32,7 +32,7 @@ print("Hello", "python")
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} }
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of `6`/
-      expect(json["fingerprint"]).to eq("42b832387c997f54a2012efb2159aefc")
+      expect(json["fingerprint"]).to eq("3f3d34361bcaef98839d9da6ca9fcee4")
     end
 
     it "prints an issue for similar code" do
@@ -60,7 +60,7 @@ print("Hello from the other side", "python")
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} }
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of `6`/
-      expect(json["fingerprint"]).to eq("42b832387c997f54a2012efb2159aefc")
+      expect(json["fingerprint"]).to eq("019118ceed60bf40b35aad581aae1b02")
     end
 
 

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -44,7 +44,7 @@ module CC::Engine::Analyzers
           {"path" => "foo.rb", "lines" => { "begin" => 9, "end" => 13} },
         ])
         expect(json["content"]["body"]).to match /This issue has a mass of `18`/
-        expect(json["fingerprint"]).to eq("f21b75bbd135ec3ae6638364d5c73762")
+        expect(json["fingerprint"]).to eq("b7e46d8f5164922678e48942e26100f2")
       end
 
       it "creates an issue for each occurrence of the duplicated code" do

--- a/spec/cc/engine/analyzers/violations_spec.rb
+++ b/spec/cc/engine/analyzers/violations_spec.rb
@@ -43,7 +43,7 @@ module CC::Engine::Analyzers
           { :path => "file.rb", :lines => { :begin => 9, :end => 13} },
           { :path => "file.rb", :lines => { :begin => 17, :end => 21} },
         ])
-        expect(first_formatted[:fingerprint]).to eq("c2712b56bff2becf4ae2a8469e1171c7")
+        expect(first_formatted[:fingerprint]).to eq("f52d2f61a77c569513f8b6314a00d013")
 
         expect(second_formatted[:location]).to eq({:path=>"file.rb", :lines=>{:begin=>9, :end=>13}})
         expect(second_formatted[:other_locations]).to eq([


### PR DESCRIPTION
Using the number of occurrences of duplicated code as a unique
identifier of the issue makes the fingerprint non-deterministic
with respect to a given issue at a site of the duplicated code.

Opting to use checkname instead.

Fixes false positives in PR comparisons: https://codeclimate.com/repos/569fa9e70c40f068790031e2/pull/3#duplication

cc @codeclimate/review