### PR TITLE
Update penalty algorithm for PHP and JavaScript

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -13,6 +13,8 @@ module CC
           ::RuntimeError,
         ].freeze
 
+        BASE_POINTS = 1_500_000
+
         def initialize(engine_config:)
           @engine_config = engine_config
         end
@@ -37,12 +39,21 @@ module CC
         end
 
         def calculate_points(mass)
-          self.class::BASE_POINTS * mass
+          overage = mass - mass_threshold
+          base_points + (overage * points_per_overage)
         end
 
         private
 
         attr_reader :engine_config
+
+        def base_points
+          self.class::BASE_POINTS
+        end
+
+        def points_per_overage
+          self.class::POINTS_PER_OVERAGE
+        end
 
         def process_file(path)
           raise NoMethodError.new("Subclass must implement `process_file`")

--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -16,7 +16,7 @@ module CC
           ]
           LANGUAGE = "javascript"
           DEFAULT_MASS_THRESHOLD = 40
-          BASE_POINTS = 3000
+          POINTS_PER_OVERAGE = 30_000
 
           private
 

--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -15,7 +15,7 @@ module CC
             "**/*.module"
           ]
           DEFAULT_MASS_THRESHOLD = 10
-          BASE_POINTS = 4_000
+          POINTS_PER_OVERAGE = 100_000
 
           private
 

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -13,18 +13,9 @@ module CC
           LANGUAGE = "python"
           DEFAULT_PATHS = ["**/*.py"]
           DEFAULT_MASS_THRESHOLD = 32
-          BASE_POINTS = 1_500_000
           POINTS_PER_OVERAGE = 50_000
 
-          def calculate_points(mass)
-            BASE_POINTS + (overage(mass) * POINTS_PER_OVERAGE)
-          end
-
           private
-
-          def overage(mass)
-            mass - mass_threshold
-          end
 
           def process_file(path)
             Node.new(::CC::Engine::Analyzers::Python::Parser.new(File.binread(path), path).parse.syntax_tree, path).format

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -18,19 +18,10 @@ module CC
 
           ]
           DEFAULT_MASS_THRESHOLD = 18
-          BASE_POINTS = 1_500_000
           POINTS_PER_OVERAGE = 100_000
           TIMEOUT = 300
 
-          def calculate_points(mass)
-            BASE_POINTS + (overage(mass) * POINTS_PER_OVERAGE)
-          end
-
           private
-
-          def overage(mass)
-            mass - mass_threshold
-          end
 
           def process_file(file)
             RubyParser.new.process(File.binread(file), file, TIMEOUT)

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(33_000)
+      expect(json["remediation_points"]).to eq(1_800_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} }
@@ -55,7 +55,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(33_000)
+      expect(json["remediation_points"]).to eq(1_800_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} }

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
         "path" => "foo.php",
         "lines" => { "begin" => 2, "end" => 6 },
       })
-      expect(json["remediation_points"]).to eq(44_000)
+      expect(json["remediation_points"]).to eq(2_100_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.php", "lines" => { "begin" => 10, "end" => 14} },
       ])


### PR DESCRIPTION
Bug fix to make penalty calculation harsher. Matches classic.

Refactor methods and defaults to make use of base class.

Additional tuning of threshold (and `per_overage_points` values) for PHP and JavaScript to come. 

On classic, base = 1_500_000, per = 50_000, for both.
For now, I made per_point value proportional to threshold.

An important consequence of this change is that grades will drop. 

@codeclimate/review 