### PR TITLE
Add pending spec for over-escaped multibyte source

### DIFF
--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -8,6 +8,19 @@ module CC::Engine::Analyzers
     include AnalyzerSpecHelpers
 
     describe "#run" do
+      it "handles escaped multibyte characters in regular expressions" do
+        create_source_file("foo.rb", <<-EORUBY)
+          class Helper
+            def self.sub_degrees(str)
+              str.gsub(/\\d+\\°\\s/, "")
+            end
+          end
+        EORUBY
+
+        pending "Potential lexing bug. Ask customer to remove escaping."
+        run_engine(engine_conf).strip.split("\0")
+      end
+
       it "prints an issue" do
         create_source_file("foo.rb", <<-EORUBY)
             describe '#ruby?' do


### PR DESCRIPTION
Some customers have code with escaped multibyte characters in regular
expressions. This causes the engine to error because File.read doubly-escapes
it, which fails to parse.

The escaping these customers have is not needed. They can remove their
backslash and all should work fine. That's what we're prescribing for now via
customer services, since all other options are too time-consuming.

Eventually, we would like to support this code as-is (as we do any realistic
source files customers may have) -- when/if we do, this spec will pass.

/cc @codeclimate/review