### PR TITLE
Customize GC behavior differently

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,6 @@ RUN npm install
 
 USER app
 
-# starting heap, max heap
-ENV JAVA_OPTS="-Xms512m -Xmx1280m"
+ENV JAVA_OPTS="-XX:+UseParNewGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10"
 
 CMD ["/usr/src/app/bin/duplication"]


### PR DESCRIPTION
By default, the JVM does not free allocated heap back to the OS. This
configures away from that behavior, hopefully to prevent OOM engine errors. It
replaces the existing configuration which put absolute size limits on the heap.

See http://www.stefankrause.net/wp/?p=14 for details on the specific options
chosen. This configuration brought my test repository's memory usage down from
~700MB to ~250MB. Its graph also shows most closely the pattern we'd prefer:
the slope of allocated heap closely matching used.

/cc @codeclimate/review

This fix was first discovered while working on
[kibit](https://github.com/andrewhr/codeclimate-kibit/pull/2). I realized this
tuning is probably good for any JVM-based engine.