### PR TITLE
Move PHP default threshold to 28

### DIFF
--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -14,7 +14,7 @@ module CC
             "**/*.inc",
             "**/*.module"
           ]
-          DEFAULT_MASS_THRESHOLD = 10
+          DEFAULT_MASS_THRESHOLD = 28
           POINTS_PER_OVERAGE = 100_000
 
           private


### PR DESCRIPTION
When analyzing the WordPress project at the current default mass threshold of
10, it was observed that Duplications found only by Platform had masses of 27
or less, while Duplications found by both Platform and Classic had masses of 28
or greater. Note: there were no Duplications found only by Classic.

Therefore, a threshold of 28 should ensure an analysis on Platform emits the
same Duplication issues as on Classic.

/cc @codeclimate/review @noahd1

I think this could be shipped without a Changelog. It should cause a small
*uptick* in GPA. For example, WordPress went from 0.85 to 0.88.