### PR TITLE
bump ruby_parser & sexp_processor

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,9 +30,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    ruby_parser (3.7.3)
+    ruby_parser (3.8.0)
       sexp_processor (~> 4.1)
-    sexp_processor (4.6.1)
+    sexp_processor (4.7.0)
     slop (3.6.0)
 
 PLATFORMS


### PR DESCRIPTION
New releases today with Ruby 2.3 support. I guess the ones we updated to yesterday didn't have all of that support, or maybe I misread commit logs.

FYI @codeclimate/review