### PR TITLE
Simplify FileList building

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -62,8 +62,7 @@ module CC
         def file_list
           @_file_list ||= ::CC::Engine::Analyzers::FileList.new(
             engine_config: engine_config,
-            default_paths: self.class::DEFAULT_PATHS,
-            language: self.class::LANGUAGE
+            patterns: self.class::PATTERNS,
           )
         end
       end

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -26,10 +26,6 @@ module CC
           end
         end
 
-        def paths_for(language)
-          fetch_language(language).fetch("paths", nil)
-        end
-
         private
 
         attr_reader :config

--- a/lib/cc/engine/analyzers/file_list.rb
+++ b/lib/cc/engine/analyzers/file_list.rb
@@ -4,63 +4,37 @@ module CC
   module Engine
     module Analyzers
       class FileList
-        def initialize(engine_config:, default_paths:, language:)
+        def initialize(engine_config:, patterns:)
           @engine_config = engine_config
-          @default_paths = default_paths
-          @language = language
+          @patterns = patterns
         end
 
         def files
-          Array(matching_files) & Array(included_files)
+          engine_config.include_paths.flat_map do |path|
+            if path.end_with?("/")
+              expand(path)
+            elsif matches?(path)
+              [path]
+            else
+              []
+            end
+          end
         end
 
         private
 
-        attr_reader :engine_config, :default_paths, :language
+        attr_reader :engine_config, :patterns
 
-        def matching_files
-          paths.map do |glob|
-            Dir.glob("./#{glob}").reject do |path|
-              File.directory?(path)
-            end
-          end.flatten
+        def expand(path)
+          globs = patterns.map { |p| File.join(path, p) }
+
+          Dir.glob(globs)
         end
 
-        def paths
-          engine_paths || default_paths
-        end
-
-        def engine_paths
-          @engine_config.paths_for(language)
-        end
-
-        def included_files
-          include_paths.
-            map { |path| make_relative(path) }.
-            map { |path| collect_files(path) }.flatten.compact
-        end
-
-        def collect_files(path)
-          if File.directory?(path)
-            Dir.entries(path).map do |new_path|
-              next if [".", ".."].include?(new_path)
-              collect_files File.join(path, new_path)
-            end
-          else
-            path
+        def matches?(path)
+          patterns.any? do |p|
+            File.fnmatch?(File.join("./", p), path, File::FNM_PATHNAME)
           end
-        end
-
-        def make_relative(path)
-          if path.match(%r(^\./))
-            path
-          else
-            "./#{path}"
-          end
-        end
-
-        def include_paths
-          engine_config.include_paths
         end
       end
     end

--- a/lib/cc/engine/analyzers/file_list.rb
+++ b/lib/cc/engine/analyzers/file_list.rb
@@ -26,15 +26,24 @@ module CC
         attr_reader :engine_config, :patterns
 
         def expand(path)
-          globs = patterns.map { |p| File.join(path, p) }
+          globs = patterns.map { |p| File.join(relativize(path), p) }
 
           Dir.glob(globs)
         end
 
         def matches?(path)
           patterns.any? do |p|
-            File.fnmatch?(File.join("./", p), path, File::FNM_PATHNAME)
+            File.fnmatch?(
+              relativize(p),
+              relativize(path),
+              File::FNM_PATHNAME | File::FNM_EXTGLOB
+            )
           end
+        end
+
+        # Ensure all paths (and patterns) are ./-prefixed
+        def relativize(path)
+          "./#{path.sub(%r{^\./}, "")}"
         end
       end
     end

--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -10,7 +10,7 @@ module CC
     module Analyzers
       module Javascript
         class Main < CC::Engine::Analyzers::Base
-          DEFAULT_PATHS = [
+          PATTERNS = [
             "**/*.js",
             "**/*.jsx"
           ]

--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -9,7 +9,7 @@ module CC
       module Php
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "php"
-          DEFAULT_PATHS = [
+          PATTERNS = [
             "**/*.php",
             "**/*.inc",
             "**/*.module"

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -11,7 +11,7 @@ module CC
       module Python
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "python"
-          DEFAULT_PATHS = ["**/*.py"]
+          PATTERNS = ["**/*.py"]
           DEFAULT_MASS_THRESHOLD = 32
           POINTS_PER_OVERAGE = 50_000
 

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -9,7 +9,7 @@ module CC
       module Ruby
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "ruby"
-          DEFAULT_PATHS = [
+          PATTERNS = [
             "**/*.rb",
             "**/*.rake",
             "**/Rakefile",

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -47,34 +47,6 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
     end
   end
 
-  describe "#paths_for" do
-    it "returns paths values for given language" do
-      engine_config = CC::Engine::Analyzers::EngineConfig.new({
-        "config" => {
-          "languages" => {
-            "EliXiR" => {
-              "paths" => ["/", "/etc"],
-            }
-          }
-        }
-      })
-
-      expect(engine_config.paths_for("elixir")).to eq(["/", "/etc"])
-    end
-
-    it "returns nil if language is an empty key" do
-      engine_config = CC::Engine::Analyzers::EngineConfig.new({
-        "config" => {
-          "languages" => {
-            "EliXiR" => ""
-          }
-        }
-      })
-
-      expect(engine_config.paths_for("elixir")).to be_nil
-    end
-  end
-
   describe "mass_threshold_for" do
     it "returns configured mass threshold as integer" do
       engine_config = CC::Engine::Analyzers::EngineConfig.new({
@@ -103,7 +75,7 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
     end
   end
 
-  describe "exlude_paths" do
+  describe "include_paths" do
     it "returns given include paths" do
       engine_config = CC::Engine::Analyzers::EngineConfig.new({
         "include_paths" => ["/tmp"]

--- a/spec/cc/engine/analyzers/file_list_spec.rb
+++ b/spec/cc/engine/analyzers/file_list_spec.rb
@@ -21,65 +21,26 @@ RSpec.describe CC::Engine::Analyzers::FileList do
   end
 
   describe "#files" do
-    it "returns files from default_paths when language is missing paths" do
+    it "expands patterns for directory includes" do
       file_list = ::CC::Engine::Analyzers::FileList.new(
-        engine_config: CC::Engine::Analyzers::EngineConfig.new({}),
-        default_paths: ["**/*.js", "**/*.jsx"],
-        language: "javascript",
+        engine_config: CC::Engine::Analyzers::EngineConfig.new(
+          "include_paths" => ["./"],
+        ),
+        patterns: ["**/*.js", "**/*.jsx"],
       )
 
       expect(file_list.files).to eq(["./foo.js", "./foo.jsx"])
     end
 
-    it "returns files from engine config defined paths when present" do
+    it "filters file includes by patterns" do
       file_list = ::CC::Engine::Analyzers::FileList.new(
-        engine_config: CC::Engine::Analyzers::EngineConfig.new({
-          "config" => {
-            "languages" => {
-              "elixir" => {
-                "paths" => ["**/*.ex"]
-              }
-            }
-          }
-        }),
-        default_paths: ["**/*.js", "**/*.jsx"],
-        language: "elixir",
+        engine_config: CC::Engine::Analyzers::EngineConfig.new(
+          "include_paths" => ["./foo.ex", "./foo.js"],
+        ),
+        patterns: ["**/*.js", "**/*.jsx"],
       )
 
-      expect(file_list.files).to eq(["./foo.ex"])
-    end
-
-    it "returns files from default_paths when languages is an array" do
-      file_list = ::CC::Engine::Analyzers::FileList.new(
-        engine_config: CC::Engine::Analyzers::EngineConfig.new({
-          "config" => {
-            "languages" => [
-              "elixir"
-            ],
-          },
-        }),
-        default_paths: ["**/*.js", "**/*.jsx"],
-        language: "javascript",
-      )
-
-      expect(file_list.files).to eq(["./foo.js", "./foo.jsx"])
-    end
-
-    it "excludes files not in include_paths" do
-      file_list = ::CC::Engine::Analyzers::FileList.new(
-        engine_config: CC::Engine::Analyzers::EngineConfig.new({
-          "include_paths" => ["foo.jsx", "nested"],
-          "config" => {
-            "languages" => [
-              "elixir"
-            ],
-          },
-        }),
-        default_paths: ["**/*.js", "**/*.jsx", "**/*.hs"],
-        language: "javascript",
-      )
-
-      expect(file_list.files).to eq(["./foo.jsx", "./nested/nest.hs"])
+      expect(file_list.files).to eq(["./foo.js"])
     end
   end
 end


### PR DESCRIPTION
The existing algorithm was hard to follow and prone to expanding large
directories that should be completely ignored. The new algorithm is the simpler
one used by most engines.

The only difference in this engine is that we also do glob-filtering on a
per-language basis. This used to be configurable, but that fact was not
advertised and is likely not being used. The constant was renamed accordingly.

This should fix #106

/cc @codeclimate/review