### PR TITLE
Ensure FileList never emits directories

### DIFF
--- a/lib/cc/engine/analyzers/file_list.rb
+++ b/lib/cc/engine/analyzers/file_list.rb
@@ -28,11 +28,11 @@ module CC
         def expand(path)
           globs = patterns.map { |p| File.join(relativize(path), p) }
 
-          Dir.glob(globs)
+          Dir.glob(globs).select { |f| File.file?(f) }
         end
 
         def matches?(path)
-          patterns.any? do |p|
+          File.file?(path) && patterns.any? do |p|
             File.fnmatch?(
               relativize(p),
               relativize(path),

--- a/spec/cc/engine/analyzers/file_list_spec.rb
+++ b/spec/cc/engine/analyzers/file_list_spec.rb
@@ -42,5 +42,20 @@ RSpec.describe CC::Engine::Analyzers::FileList do
 
       expect(file_list.files).to eq(["./foo.js"])
     end
+
+    it "does not emit directories even if they match the patterns" do
+      file_list = ::CC::Engine::Analyzers::FileList.new(
+        engine_config: CC::Engine::Analyzers::EngineConfig.new(
+          "include_paths" => ["./"],
+        ),
+        patterns: ["**/*.js"],
+      )
+
+      Dir.mkdir("vendor.js")
+      File.write(File.join(@tmp_dir, "vendor.js", "vendor.src.js"), "")
+
+      expect(file_list.files).to include("./vendor.js/vendor.src.js")
+      expect(file_list.files).not_to include("./vendor.js")
+    end
   end
 end


### PR DESCRIPTION
Apparently it's common for JavaScript projects to have a path like:

    ./foo.js/foo.src.js

Since the directory matches `**/*.js`, directory expansions emits it as a file
and the analyzer errors (`EISDIR`) trying to read it.

The solution is to ensure we only ever emit files from the glob-expansion. The
additional guard in `#matches?` is not strictly necessary but was added to
increase robustness in case upstream logic changes and the entries in
include-paths become unreliable as to their file-vs-directory-ness.

/cc @codeclimate/review