### PR TITLE
Mention possibility to exclude files

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,10 @@ the Hash type to support extra configuration.
 
 ### Excluding files and directories
 
-As with any other Codeclimate engine, you can exclude certain files or directories from being analyzed. For more information, [see *Exclude paths for specific engines* on our documentation][exclude-files-engine].
+As with any other Code Climate engine, you can exclude certain files or
+directories from being analyzed. For more information, see
+[*Exclude paths for specific engines*][exclude-files-engine] in our
+documentation.
 
 ```yaml
 engines:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,19 @@ engines:
 Note that you have the update the YAML structure under the `languages` key to
 the Hash type to support extra configuration.
 
+### Excluding files and directories
+
+As with any other Codeclimate engine, you can exclude certain files or directories from being analyzed. For more information, [see *Exclude paths for specific engines* on our documentation][exclude-files-engine].
+
+```yaml
+engines:
+  duplication:
+    exclude_paths:
+    - examples/
+```
+
 [codeclimate]: https://codeclimate.com/dashboard
 [what-is-duplication]: https://docs.codeclimate.com/docs/duplication-concept
 [flay]: https://github.com/seattlerb/flay
 [cli]: https://github.com/codeclimate/codeclimate
+[exclude-files-engine]: https://docs.codeclimate.com/docs/excluding-files-and-folders#section-exclude-paths-for-specific-engines


### PR DESCRIPTION
The option is part of the "global settings", but what those global settings are and that they exist isn't obvious from the README. The documentation shown when clicking on duplication errors on `codeclimate.com` also does not mention this at all.

This is probably a good entry point for people looking for it.

Relates to #115.