### PR TITLE
Abort when an exception is raised

### DIFF
--- a/lib/cc/engine/analyzers/file_thread_pool.rb
+++ b/lib/cc/engine/analyzers/file_thread_pool.rb
@@ -7,6 +7,8 @@ module CC
         DEFAULT_CONCURRENCY = 2
         MAX_CONCURRENCY = 2
 
+        Thread.abort_on_exception = true
+
         def initialize(files, concurrency: DEFAULT_CONCURRENCY)
           @files = files
           @concurrency = concurrency


### PR DESCRIPTION
This change fixes behavior where a JVM OOM exception sometimes did not result
in the engine raising an error and crashing.