### PR TITLE
Use the spreadRestParams plugin for Babylon

### DIFF
--- a/lib/cc/engine/analyzers/javascript/parser.js
+++ b/lib/cc/engine/analyzers/javascript/parser.js
@@ -19,7 +19,7 @@ process.stdin.on('data', function(chunk) {
 });
 
 process.stdin.on('end', function() {
-  var ast = babylon.parse(source, { plugins: ["jsx"], strictMode: false, sourceType: "module" });
+  var ast = babylon.parse(source, { plugins: ["jsx", "objectRestSpread"], strictMode: false, sourceType: "module" });
   var program = ast.program;
   console.log(
     JSON.stringify(format(program))

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -64,6 +64,19 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
       expect(json["fingerprint"]).to eq("d9dab8e4607e2a74da3b9eefb49eacec")
     end
 
+    it "handles ES6 spread params" do
+      create_source_file("foo.jsx", <<-EOJS)
+        const ThingClass = React.createClass({
+          propTypes: {
+            ...OtherThing.propTypes,
+            otherProp: "someVal"
+          }
+        });
+      EOJS
+
+      expect { run_engine(engine_conf) }.not_to output(/Skipping file/).to_stderr
+    end
+
     it "skips unparsable files" do
       create_source_file("foo.js", <<-EOJS)
         function () { do(); // missing closing brace


### PR DESCRIPTION
From CX escalation: parsing spread params (e.g. `...foo`) in Babylon
requires enabling a plugin.

cc @codeclimate/review