### PR TITLE
Reorder npm install/package.json copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ COPY Gemfile.lock /usr/src/app/
 COPY vendor/php-parser/composer.json /usr/src/app/vendor/php-parser/
 COPY vendor/php-parser/composer.lock /usr/src/app/vendor/php-parser/
 
+COPY package.json /usr/src/app/
+
 RUN curl --silent --location https://deb.nodesource.com/setup_5.x | bash - && \
     apt-get update && apt-get install -y nodejs python openssh-client php5-cli php5-json
 RUN gem install bundler --no-ri --no-rdoc && \
@@ -16,12 +18,12 @@ RUN gem install bundler --no-ri --no-rdoc && \
 
 RUN mv composer.phar /usr/local/bin/composer
 RUN cd /usr/src/app/vendor/php-parser/ && composer install --prefer-source --no-interaction
+RUN npm install
 
 RUN adduser app -u 9000
 
 COPY . /usr/src/app
 RUN chown -R app .
-RUN npm install
 
 USER app
 


### PR DESCRIPTION
This treats this more like other dependencies, and stops us from doing
`npm install` on every single build.

cc @codeclimate/review