### PR TITLE
Tweak JVM config to increase heap size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,5 @@ RUN chown -R app .
 
 USER app
 
-ENV JAVA_OPTS="-XX:+UseParNewGC -XX:MinHeapFreeRatio=5 -XX:MaxHeapFreeRatio=10"
-
+ENV JAVA_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=40 -XX:MaxHeapFreeRatio=70 -Xmx1024m"
 CMD ["/usr/src/app/bin/duplication"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,8 @@ RUN chown -R app .
 
 USER app
 
+WORKDIR /code
+VOLUME /code
+
 ENV JAVA_OPTS="-XX:+UseParallelGC -XX:MinHeapFreeRatio=40 -XX:MaxHeapFreeRatio=70 -Xmx1024m"
 CMD ["/usr/src/app/bin/duplication"]

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ image:
 	docker build --rm -t $(IMAGE_NAME) .
 
 test: image
-	docker run --tty --interactive --rm $(IMAGE_NAME) bundle exec rake
+	docker run --tty --interactive --rm $(IMAGE_NAME) sh -c "cd /usr/src/app && bundle exec rake"
 
 citest:
-	docker run --rm $(IMAGE_NAME) bundle exec rake
+	docker run --rm $(IMAGE_NAME) sh -c "cd /usr/src/app && bundle exec rake"

--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ test:
 
 deployment:
   registry:
-    branch: master
+    branch: /master|channel\/[\w-]+/
     commands:
       - >
         docker run

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -10,6 +10,7 @@ module CC
           ::Errno::ENOENT,
           ::Racc::ParseError,
           ::RubyParser::SyntaxError,
+          ::RuntimeError,
         ].freeze
 
         BASE_POINTS = 1_500_000

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -10,7 +10,6 @@ module CC
           ::Errno::ENOENT,
           ::Racc::ParseError,
           ::RubyParser::SyntaxError,
-          ::RuntimeError,
         ].freeze
 
         BASE_POINTS = 1_500_000

--- a/lib/cc/engine/analyzers/command_line_runner.rb
+++ b/lib/cc/engine/analyzers/command_line_runner.rb
@@ -13,6 +13,7 @@ module CC
         end
 
         def run(input)
+          Thread.abort_on_exception = false
           Timeout.timeout(timeout) do
             out, err, status = Open3.capture3(command, stdin_data: input)
 
@@ -24,6 +25,8 @@ module CC
               raise ::CC::Engine::Analyzers::ParserError, "`#{command}` exited with code #{status.exitstatus}:\n#{err}"
             end
           end
+        ensure
+          Thread.abort_on_exception = true
         end
 
         private

--- a/lib/cc/engine/analyzers/file_thread_pool.rb
+++ b/lib/cc/engine/analyzers/file_thread_pool.rb
@@ -7,13 +7,14 @@ module CC
         DEFAULT_CONCURRENCY = 2
         MAX_CONCURRENCY = 2
 
+        Thread.abort_on_exception = true
+
         def initialize(files, concurrency: DEFAULT_CONCURRENCY)
           @files = files
           @concurrency = concurrency
         end
 
         def run(&block)
-          Thread.abort_on_exception = true
           queue = build_queue
           lock = Mutex.new
 
@@ -24,8 +25,6 @@ module CC
               end
             end
           end
-        ensure
-          Thread.abort_on_exception = false
         end
 
         def join

--- a/lib/cc/engine/analyzers/file_thread_pool.rb
+++ b/lib/cc/engine/analyzers/file_thread_pool.rb
@@ -7,6 +7,8 @@ module CC
         DEFAULT_CONCURRENCY = 2
         MAX_CONCURRENCY = 2
 
+        Thread.abort_on_exception = true
+
         def initialize(files, concurrency: DEFAULT_CONCURRENCY)
           @files = files
           @concurrency = concurrency

--- a/lib/cc/engine/analyzers/file_thread_pool.rb
+++ b/lib/cc/engine/analyzers/file_thread_pool.rb
@@ -7,14 +7,13 @@ module CC
         DEFAULT_CONCURRENCY = 2
         MAX_CONCURRENCY = 2
 
-        Thread.abort_on_exception = true
-
         def initialize(files, concurrency: DEFAULT_CONCURRENCY)
           @files = files
           @concurrency = concurrency
         end
 
         def run(&block)
+          Thread.abort_on_exception = true
           queue = build_queue
           lock = Mutex.new
 
@@ -25,6 +24,8 @@ module CC
               end
             end
           end
+        ensure
+          Thread.abort_on_exception = false
         end
 
         def join


### PR DESCRIPTION
- Tune heap parameters
  We have seen `java.lang.OutOfMemoryError: Java heap space` errors
  The default heap size is 512mb. Increase to 1024.

  Overview of Heap tuning options:
  https://docs.oracle.com/cd/E19159-01/819-3681/6n5srlhqp/index.html

  The min and max heap ratios determine the min and max amount of free space
  permitted between garbage collections, as a percentage. The defaults are
  40 and 70 resp, according to
  http://www.avricot.com/blog/?post/2010/05/03/Get-started-with-java-JVM-memory-(heap%2C-stack%2C-xss-xms-xmx-xmn...)

- Use Parallel GC instead of ParNew which is deprecated when used with the
  SerialOld Parser.

  See: http://openjdk.java.net/jeps/173