### PR TITLE
Raise OOM error

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ test:
 
 deployment:
   registry:
-    branch: master
+    branch: /master|channel\/[\w-]+/
     commands:
       - >
         docker run

--- a/lib/cc/engine/analyzers/file_thread_pool.rb
+++ b/lib/cc/engine/analyzers/file_thread_pool.rb
@@ -16,8 +16,8 @@ module CC
           queue = build_queue
           lock = Mutex.new
 
-          @workers = thread_count.times.map do
-            Thread.new do
+          @workers = Array.new(thread_count) do
+            with_thread_abortion do
               while (item = next_item(queue, lock))
                 yield item
               end
@@ -53,6 +53,13 @@ module CC
           else
             DEFAULT_CONCURRENCY
           end
+        end
+
+        def with_thread_abortion
+          t = Thread.new do
+            yield
+          end
+          (t.abort_on_exception = true) && t
         end
       end
     end

--- a/spec/cc/engine/analyzers/file_thread_pool_spec.rb
+++ b/spec/cc/engine/analyzers/file_thread_pool_spec.rb
@@ -3,8 +3,9 @@ require "cc/engine/analyzers/file_thread_pool"
 
 RSpec.describe CC::Engine::Analyzers::FileThreadPool do
   describe "#run" do
+    let(:thread) { Thread.new {} }
     it "uses default count of threads when concurrency is not specified" do
-      allow(Thread).to receive(:new)
+      allow(Thread).to receive(:new).and_return(thread)
 
       pool = CC::Engine::Analyzers::FileThreadPool.new([])
       pool.run  {}
@@ -15,7 +16,7 @@ RSpec.describe CC::Engine::Analyzers::FileThreadPool do
     end
 
     it "uses default concurrency when concurrency is over max" do
-      allow(Thread).to receive(:new)
+      allow(Thread).to receive(:new).and_return(thread)
 
       run_pool_with_concurrency(
         CC::Engine::Analyzers::FileThreadPool::DEFAULT_CONCURRENCY + 2
@@ -27,7 +28,7 @@ RSpec.describe CC::Engine::Analyzers::FileThreadPool do
     end
 
     it "uses default concucurrency when concucurrency is under 1" do
-      allow(Thread).to receive(:new)
+      allow(Thread).to receive(:new).and_return(thread)
 
       run_pool_with_concurrency(-2)
 
@@ -37,7 +38,7 @@ RSpec.describe CC::Engine::Analyzers::FileThreadPool do
     end
 
     it "uses supplied concurrency when valid" do
-      allow(Thread).to receive(:new)
+      allow(Thread).to receive(:new).and_return(thread)
 
       run_pool_with_concurrency(1)
 
@@ -56,6 +57,14 @@ RSpec.describe CC::Engine::Analyzers::FileThreadPool do
       expect(results).to include("cba")
       expect(results).to include("321")
       expect(results).to include("zyx")
+    end
+
+    it "aborts on a thread exception" do
+      allow(Thread).to receive(:new).and_return(thread)
+
+      run_pool_with_concurrency(1)
+
+      expect(thread.abort_on_exception).to eq(true)
     end
   end
 


### PR DESCRIPTION
@codeclimate/review 

Abort when exception is raised during analysis
Fixes an issue where Java OOM exceptions were swallowed and could result in
issues getting dropped.

We suppress the thread abort behavior in the CommandLine Runner class to
ensure we get a meaningful error whene there's a timeout, instead of an
IOError.

See individual commits for details on other changes.

Thanks to @maxjacobson for help confirming this behavior. 

Closes https://github.com/codeclimate/codeclimate-duplication/pull/130/files

(The JAVA_OPTS tuning isn't quite right in pull 130 and should be addressed separately).
