### PR TITLE
Revert "Raise OOM error"

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -20,7 +20,7 @@ test:
 
 deployment:
   registry:
-    branch: /master|channel\/[\w-]+/
+    branch: master
     commands:
       - >
         docker run

--- a/lib/cc/engine/analyzers/file_thread_pool.rb
+++ b/lib/cc/engine/analyzers/file_thread_pool.rb
@@ -16,8 +16,8 @@ module CC
           queue = build_queue
           lock = Mutex.new
 
-          @workers = Array.new(thread_count) do
-            with_thread_abortion do
+          @workers = thread_count.times.map do
+            Thread.new do
               while (item = next_item(queue, lock))
                 yield item
               end
@@ -53,13 +53,6 @@ module CC
           else
             DEFAULT_CONCURRENCY
           end
-        end
-
-        def with_thread_abortion
-          t = Thread.new do
-            yield
-          end
-          (t.abort_on_exception = true) && t
         end
       end
     end

--- a/spec/cc/engine/analyzers/file_thread_pool_spec.rb
+++ b/spec/cc/engine/analyzers/file_thread_pool_spec.rb
@@ -3,9 +3,8 @@ require "cc/engine/analyzers/file_thread_pool"
 
 RSpec.describe CC::Engine::Analyzers::FileThreadPool do
   describe "#run" do
-    let(:thread) { Thread.new {} }
     it "uses default count of threads when concurrency is not specified" do
-      allow(Thread).to receive(:new).and_return(thread)
+      allow(Thread).to receive(:new)
 
       pool = CC::Engine::Analyzers::FileThreadPool.new([])
       pool.run  {}
@@ -16,7 +15,7 @@ RSpec.describe CC::Engine::Analyzers::FileThreadPool do
     end
 
     it "uses default concurrency when concurrency is over max" do
-      allow(Thread).to receive(:new).and_return(thread)
+      allow(Thread).to receive(:new)
 
       run_pool_with_concurrency(
         CC::Engine::Analyzers::FileThreadPool::DEFAULT_CONCURRENCY + 2
@@ -28,7 +27,7 @@ RSpec.describe CC::Engine::Analyzers::FileThreadPool do
     end
 
     it "uses default concucurrency when concucurrency is under 1" do
-      allow(Thread).to receive(:new).and_return(thread)
+      allow(Thread).to receive(:new)
 
       run_pool_with_concurrency(-2)
 
@@ -38,7 +37,7 @@ RSpec.describe CC::Engine::Analyzers::FileThreadPool do
     end
 
     it "uses supplied concurrency when valid" do
-      allow(Thread).to receive(:new).and_return(thread)
+      allow(Thread).to receive(:new)
 
       run_pool_with_concurrency(1)
 
@@ -57,14 +56,6 @@ RSpec.describe CC::Engine::Analyzers::FileThreadPool do
       expect(results).to include("cba")
       expect(results).to include("321")
       expect(results).to include("zyx")
-    end
-
-    it "aborts on a thread exception" do
-      allow(Thread).to receive(:new).and_return(thread)
-
-      run_pool_with_concurrency(1)
-
-      expect(thread.abort_on_exception).to eq(true)
     end
   end
 


### PR DESCRIPTION
Reverts codeclimate/codeclimate-duplication#132

We're holding release on this for a little while to do some due diligence on how many builds it's likely to impact. We expect this to increase errored builds since previously a JRuby bug was effectively hiding a class of failures, but want to understand what percentage of repos are likely to be impacted & if there are other remediations we should implement before fully releasing this fix.

cc @codeclimate/review 