### PR TITLE
Use fetch_language to coerce python config

### DIFF
--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -30,10 +30,6 @@ module CC
           end
         end
 
-        private
-
-        attr_reader :config
-
         def fetch_language(language)
           language = config.
             fetch("languages", {}).
@@ -45,6 +41,10 @@ module CC
             {}
           end
         end
+
+        private
+
+        attr_reader :config
 
         def normalize(hash)
           hash.tap do |config|

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -27,7 +27,7 @@ module CC
           end
 
           def python_version
-            engine_config.languages.fetch("python", {}).fetch("python_version", DEFAULT_PYTHON_VERSION)
+            engine_config.fetch_language(LANGUAGE).fetch("python_version", DEFAULT_PYTHON_VERSION)
           end
         end
       end

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -117,6 +117,23 @@ def c(thing: str):
     end
   end
 
+  it "handles an empty yml key in config" do
+      create_source_file("foo.py", <<-EOPY)
+def a(thing):
+  print("Hello", thing)
+      EOPY
+
+      conf = CC::Engine::Analyzers::EngineConfig.new({
+      "config" => {
+        "languages" => {
+          "python" => ""
+        }
+      }
+    })
+
+    expect(run_engine(engine_conf)).to eq("")
+  end
+
   def engine_conf
     CC::Engine::Analyzers::EngineConfig.new({
       "config" => {


### PR DESCRIPTION
Addresses #136

The changes made in #135 didn't account for configuring the languages
with empty hash contents. With YAML parsing, something like

```
languages:
  python:
```

Gets parsed as `{ "languages" => { "python" => "" } }`, leading to a
`NoMethodError` when the Python class attempted to discover the
configured Python version.

`EngineConfig` already had logic to ensure a language configuration was
a hash, so this makes the appropriate coercing method public & uses it
from the Python class. (Since the Python version key is a Python-only
option, the `EngineConfig` class still doesn't seem like the appropriate
place for that logic.)

cc @codeclimate/review @maxjacobson