### PR TITLE
Guard against divide by zero error

### DIFF
--- a/lib/cc/engine/analyzers/javascript/minification_checker.rb
+++ b/lib/cc/engine/analyzers/javascript/minification_checker.rb
@@ -10,8 +10,10 @@ module CC
           end
 
           def minified?
-            ratio = content.chars.count / content.lines.count
-            ratio >= MINIFIED_AVG_LINE_LENGTH_CUTOFF
+            if content.lines.count != 0
+              ratio = content.chars.count / content.lines.count
+              ratio >= MINIFIED_AVG_LINE_LENGTH_CUTOFF
+            end
           end
 
           private

--- a/lib/cc/engine/analyzers/javascript/minification_checker.rb
+++ b/lib/cc/engine/analyzers/javascript/minification_checker.rb
@@ -10,7 +10,7 @@ module CC
           end
 
           def minified?
-            if content.lines.count != 0
+            if content.lines.count.nonzero?
               ratio = content.chars.count / content.lines.count
               ratio >= MINIFIED_AVG_LINE_LENGTH_CUTOFF
             end

--- a/lib/cc/engine/analyzers/javascript/minification_checker.rb
+++ b/lib/cc/engine/analyzers/javascript/minification_checker.rb
@@ -13,6 +13,8 @@ module CC
             if content.lines.count.nonzero?
               ratio = content.chars.count / content.lines.count
               ratio >= MINIFIED_AVG_LINE_LENGTH_CUTOFF
+            else
+              false
             end
           end
 

--- a/spec/cc/engine/analyzers/javascript/minification_checker_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/minification_checker_spec.rb
@@ -18,6 +18,11 @@ module CC
               path = fixture_path("normal_js_file.js")
               expect(MinificationChecker.new(path)).to_not be_minified
             end
+
+            it "returns false for empty files" do
+              path = fixture_path("empty_file.js")
+              expect(MinificationChecker.new(path)).to_not be_minified
+            end
           end
         end
       end


### PR DESCRIPTION
Fixes a bug where empty js file could cause an analysis to error

e.g. https://codeclimate.com/github/parliamentofowls/test-repo-cc/builds/1

@codeclimate/review 