### PR TITLE
Refactor away from OpenStruct for php AST

### DIFF
--- a/lib/cc/engine/analyzers/php/ast.rb
+++ b/lib/cc/engine/analyzers/php/ast.rb
@@ -19,28 +19,28 @@ module CC
             prefix_re = /^(Expr|Scalar|Stmt)_?/
             suffix_re = /_$/
 
-            Nodes::Node.new.tap do |node|
-              node.file = filename
-
-              if node_type = ast.delete("nodeType")
-                node.node_type = node_type.
+            node_attrs = {
+              file: filename,
+            }
+            if (node_type = ast.delete("nodeType"))
+              node_attrs[:node_type] = node_type.
                   sub(prefix_re, '').
                   sub(suffix_re, '')
-              end
-
-              ast.each do |key, value|
-                unless key == "nodeAttributes"
-                  case value
-                  when Hash
-                    value = json_to_ast(value, filename)
-                  when Array
-                    value = value.map { |v| json_to_ast(v, filename) }
-                  end
-
-                  node.send(:"#{key}=", value)
+            end
+            ast.each do |key, value|
+              unless key == "nodeAttributes"
+                case value
+                when Hash
+                  value = json_to_ast(value, filename)
+                when Array
+                  value = value.map { |v| json_to_ast(v, filename) }
                 end
+
+                node_attrs[key.to_sym] = value
               end
             end
+
+            Nodes::Node.new(node_attrs)
           end
         end
       end

--- a/lib/cc/engine/analyzers/php/nodes.rb
+++ b/lib/cc/engine/analyzers/php/nodes.rb
@@ -5,8 +5,13 @@ module CC
     module Analyzers
       module Php
         module Nodes
-          class Node < OpenStruct
+          class Node
+            def initialize(attrs)
+              @attrs = attrs
+            end
+
             def accept(visitor)
+              node_type = @attrs[:node_type]
               visit_method = :"visit_#{node_type}Node"
 
               if visitor.respond_to?(visit_method)
@@ -15,11 +20,19 @@ module CC
             end
 
             def line
-              startLine
+              @attrs[:startLine]
+            end
+
+            def file
+              @attrs[:file]
             end
 
             def to_sexp
               CC::Engine::Analyzers::Php::SexpVisitor.new.accept(self)
+            end
+
+            def each_pair(&block)
+              @attrs.each_pair(&block)
             end
 
             def sub_nodes

--- a/lib/cc/engine/analyzers/php/parser.rb
+++ b/lib/cc/engine/analyzers/php/parser.rb
@@ -1,4 +1,5 @@
 require "cc/engine/analyzers/command_line_runner"
+require "cc/engine/analyzers/parser_base"
 require "cc/engine/analyzers/php/ast"
 require "cc/engine/analyzers/php/nodes"
 
@@ -19,10 +20,10 @@ module CC
             runner.run(code) do |output|
               json = parse_json(output)
 
-              @syntax_tree = CC::Engine::Analyzers::Php::Nodes::Node.new.tap do |node|
-                node.stmts = CC::Engine::Analyzers::Php::AST.json_to_ast(json, filename)
-                node.node_type = "AST"
-              end
+              @syntax_tree = CC::Engine::Analyzers::Php::Nodes::Node.new(
+                stmts: CC::Engine::Analyzers::Php::AST.json_to_ast(json, filename),
+                node_type: "AST",
+              )
             end
 
             self

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
       EOPHP
 
       issues = run_engine(engine_conf).strip.split("\0")
+      expect(issues.length).to be > 0
       result = issues.first.strip
       json = JSON.parse(result)
 
@@ -51,6 +52,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
     it "runs against complex files" do
       FileUtils.cp(fixture_path("symfony_configuration.php"), File.join(@code, "configuration.php"))
       issues = run_engine(engine_conf).strip.split("\0")
+      expect(issues.length).to be > 0
       result = issues.first.strip
 
       expect(result).to match "\"type\":\"issue\""
@@ -94,6 +96,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
     it "can parse php 7 code" do
       create_source_file("foo.php", File.read(fixture_path("from_phan_php7.php")))
       issues = run_engine(engine_conf).strip.split("\0")
+      expect(issues.length).to be > 0
       result = issues.first.strip
       json = JSON.parse(result)
       expect(json["location"]).to eq({


### PR DESCRIPTION
I believe this is the root cause for many of the OOM errors we've been
seeing.

Our original analysis pointed toward:

1. repos with big minified js files (resolved by skipping those)
1. php-only repos (mysterious...)

Since ripping off the bandaid Monday and surfacing OOM errors to
end-users, we've been hearing about several PHP-only repos that are
erroring, so I took some time to read through the php parsing code
looking for a possible memory leak.

Eventually I noticed that we're using OpenStruct to represent our "Node"
concept for the php AST that we build. I've heard that OpenStruct isn't
very memory-efficient or fast and decided to try refactoring away from
it.

I'm able to reproduce the OOM error via the CLI on my clone of
etsy/phan, and the error no longer occurs with this refactor.

:tada: :tada: :tada: