### PR TITLE
Update to latest jruby

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM jruby:9.0.3-jdk
+FROM jruby:9.1.5-jdk
 
 WORKDIR /usr/src/app/
 


### PR DESCRIPTION
This is motivated by a rare error which was fixed in 9.1.3. Some more
context in this issue:

https://github.com/jruby/jruby/issues/1279