### PR TITLE
Disable debug output by default

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -23,7 +23,6 @@ module CC
           if (skip_reason = skip?(file))
             $stderr.puts("Skipping file #{file} because #{skip_reason}")
           else
-            $stderr.puts("Processing #{file}")
             process_file(file)
           end
         rescue => ex

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -23,6 +23,7 @@ module CC
           if (skip_reason = skip?(file))
             $stderr.puts("Skipping file #{file} because #{skip_reason}")
           else
+            $stderr.puts("Processing #{file}") if engine_config.debug?
             process_file(file)
           end
         rescue => ex


### PR DESCRIPTION
This was helpful for identifying potentially problematic files, and
helped lead us to identify minified js files as a problem, but it hasn't
been as helpful recently, and can actually lead to exceeding the maximum
output limit for repos with many files!