### PR TITLE
Allow hash-in-array configuration style

### DIFF
--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -3,6 +3,7 @@ module CC
     module Analyzers
       class EngineConfig
         DEFAULT_COUNT_THRESHOLD = 2
+        InvalidConfigError = Class.new(StandardError)
 
         def initialize(hash)
           @config = normalize(hash)
@@ -76,7 +77,7 @@ module CC
               map[key.downcase] = value
             end
           else
-            {}
+            raise InvalidConfigError, "languages config entry is invalid: please check documentation for details of configuring languages"
           end
         end
 
@@ -85,6 +86,8 @@ module CC
             [entry.downcase, {}]
           elsif entry.is_a?(Hash) && entry.keys.count == 1
             [entry.keys.first, entry[entry.keys.first]]
+          else
+            raise InvalidConfigError, "#{entry.inspect} is not a valid language entry"
           end
         end
       end

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -68,7 +68,8 @@ module CC
         def build_language_config(languages)
           if languages.is_a?(Array)
             languages.each_with_object({}) do |language, map|
-              map[language.downcase] = {}
+              language, config = coerce_array_entry(language)
+              map[language.downcase] = config
             end
           elsif languages.is_a?(Hash)
             languages.each_with_object({}) do |(key, value), map|
@@ -76,6 +77,14 @@ module CC
             end
           else
             {}
+          end
+        end
+
+        def coerce_array_entry(entry)
+          if entry.is_a?(String)
+            [entry.downcase, {}]
+          elsif entry.is_a?(Hash) && entry.keys.count == 1
+            [entry.keys.first, entry[entry.keys.first]]
           end
         end
       end

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -45,6 +45,22 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
 
       expect(engine_config.languages).to eq({})
     end
+
+    it "handles an array containing a hash" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => [
+            { "ruby" => { "mass_threshold" => 20 } },
+            "python"
+          ]
+        }
+      })
+
+      expect(engine_config.languages).to eq({
+        "ruby" => { "mass_threshold" => 20 },
+        "python" => {},
+      })
+    end
   end
 
   describe "mass_threshold_for" do

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -36,14 +36,16 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
       })
     end
 
-    it "returns an empty hash if languages is invalid" do
-      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+    it "raises an exception for a completely invalid config" do
+      config = {
         "config" => {
           "languages" => "potato",
-        },
-      })
+        }
+      }
 
-      expect(engine_config.languages).to eq({})
+      expect {
+        CC::Engine::Analyzers::EngineConfig.new(config)
+      }.to raise_error(CC::Engine::Analyzers::EngineConfig::InvalidConfigError)
     end
 
     it "handles an array containing a hash" do
@@ -60,6 +62,21 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
         "ruby" => { "mass_threshold" => 20 },
         "python" => {},
       })
+    end
+
+    it "raises an exception for an array containing a bad hash" do
+      config = {
+        "config" => {
+          "languages" => [
+            { "ruby" => { "mass_threshold" => 20 }, "extra_key" => 123 },
+            "python"
+          ]
+        }
+      }
+
+      expect {
+        CC::Engine::Analyzers::EngineConfig.new(config)
+      }.to raise_error(CC::Engine::Analyzers::EngineConfig::InvalidConfigError)
     end
   end
 


### PR DESCRIPTION
We saw some configs using this kind of style in the wild:

```
languages:
  - ruby:
    mass_threshold: 25
  - javascript
```

Right now, this config doesn't actually work (it gets eliminated due to validations in `cc-yaml`, and what the engine actually sees is `languages: ["javascript"]`, which is certainly not what the user wanted.

I'm working to change that behavior in `cc-yaml`, and wanted to also try to ensure that the duplication engine would have reasonable behavior once a fixed `cc-yaml` would make this style of config actually get passed through to the engine.

This adds support for this style of config, so it should start actually working once `cc-yaml` is fixed. It also explicitly raises an error for some degenerate cases where we would previously have just used the default configuration: I believe it's better to explicitly fail than to do something probably not desired by the user in those cases.

cc @codeclimate/review 