### PR TITLE
Suppress PHP notices

### DIFF
--- a/lib/cc/engine/analyzers/php/parser.rb
+++ b/lib/cc/engine/analyzers/php/parser.rb
@@ -16,7 +16,7 @@ module CC
           end
 
           def parse
-            runner = CommandLineRunner.new("php #{parser_path}")
+            runner = CommandLineRunner.new("php -d 'display_errors = Off' #{parser_path}")
             runner.run(code) do |output|
               json = parse_json(output)
 


### PR DESCRIPTION
PHP notices pollute output and trip over some specs.

Note: On CI PHP does not produce any notices. It happens when `rake spec` ran locally. This is most definitely a setup issue. I'm not sure how easy it's to mitigate it. On macOS `brew`'s PHP 5.6 spews a lot of notices in its default configuration. It makes development a bit challenging.