### PR TITLE
Call analyze directly, avoiding reporting into a StringIO.

### DIFF
--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -47,7 +47,7 @@ module CC
         end
 
         def report
-          flay.report(StringIO.new).each do |issue|
+          flay.analyze.each do |issue|
             violations = new_violations(issue)
 
             violations.each do |violation|


### PR DESCRIPTION
This also avoids relying on an report returning the data variable. It
might not in the future.

Completely untested. (rspec? *sigh*)