### PR TITLE
Enable classProperties babylon plugin

### DIFF
--- a/lib/cc/engine/analyzers/javascript/parser.js
+++ b/lib/cc/engine/analyzers/javascript/parser.js
@@ -19,7 +19,7 @@ process.stdin.on('data', function(chunk) {
 });
 
 process.stdin.on('end', function() {
-  var ast = babylon.parse(source, { plugins: ["jsx", "objectRestSpread"], strictMode: false, sourceType: "module" });
+  var ast = babylon.parse(source, { plugins: ["classProperties", "jsx", "objectRestSpread"], strictMode: false, sourceType: "module" });
   var program = ast.program;
   console.log(
     JSON.stringify(format(program))


### PR DESCRIPTION
This is necessary to parse code which looks like

```
class Foo {
  bar = => console.log("baz")
}
```

(bar is the class property)