### PR TITLE
Added Sexp.flatter and use that to optimize non-ruby analysis.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,6 @@ RUN adduser -u 9000 -D -h /usr/src/app -s /bin/false app
 COPY . /usr/src/app
 RUN chown -R app:app /usr/src/app
 
-# ENV PURE_HASH=1
-# ENV CODECLIMATE_PROFILE=1
-
 USER app
 
 CMD ["/usr/src/app/bin/duplication"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,40 @@ COPY vendor/php-parser/composer.lock /usr/src/app/vendor/php-parser/
 
 COPY package.json /usr/src/app/
 
-RUN apk update && apk add nodejs python python3 php5-phar php5-openssl php5-cli php5-json php5-zlib php5-xml
+RUN apk update && apk add python python3 php5-phar php5-openssl php5-cli php5-json php5-zlib php5-xml
 
-RUN apk add curl && \
+ENV NODE_VERSION=v5.12.0 \
+    NPM_VERSION=3
+
+# Based on https://github.com/mhart/alpine-node
+RUN apk add --no-cache curl make gcc g++ linux-headers binutils-gold gnupg libstdc++ && \
+    gpg --keyserver ha.pool.sks-keyservers.net --recv-keys \
+      94AE36675C464D64BAFA68DD7434390BDBE9B9C5 \
+      FD3A5288F042B6850C66B31F09FE44734EB7990E \
+      71DCFD284A79C3B38668286BC97EC7A07EDE3FC1 \
+      DD8F2338BAE7501E3DD5AC78C273792F7D83545D \
+      C4F0DFFF4E8C1A8236409D08E73BC641CC11F4C8 \
+      B9AE9905FFD7803F25714661B63B535A4C206CA9 \
+      56730D5401028683275BD23C23EFEFE93C4CFFFE && \
+    curl -sSLO https://nodejs.org/dist/${NODE_VERSION}/node-${NODE_VERSION}.tar.xz && \
+    curl -sSL https://nodejs.org/dist/${NODE_VERSION}/SHASUMS256.txt.asc | gpg --batch --decrypt | \
+      grep " node-${NODE_VERSION}.tar.xz\$" | sha256sum -c | grep . && \
+    tar -xf node-${NODE_VERSION}.tar.xz && \
+    cd node-${NODE_VERSION} && \
+    ./configure --prefix=/usr ${CONFIG_FLAGS} && \
+    make -j$(getconf _NPROCESSORS_ONLN) && \
+    make install && \
+    cd / && \
+    if [ -x /usr/bin/npm ]; then \
+      npm install -g npm@${NPM_VERSION} && \
+      find /usr/lib/node_modules/npm -name test -o -name .bin -type d | xargs rm -rf; \
+    fi && \
+    apk del curl make gcc g++ linux-headers binutils-gold gnupg ${DEL_PKGS} && \
+    rm -rf ${RM_DIRS} /node-${NODE_VERSION}* /usr/share/man /tmp/* /var/cache/apk/* \
+      /root/.npm /root/.node-gyp /root/.gnupg /usr/lib/node_modules/npm/man \
+      /usr/lib/node_modules/npm/doc /usr/lib/node_modules/npm/html /usr/lib/node_modules/npm/scripts
+
+RUN apk add --update curl && \
     gem install bundler --no-ri --no-rdoc && \
     bundle install -j 4 && \
     curl -sS https://getcomposer.org/installer | php && \

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -51,6 +51,10 @@ module CC
           base_points + (overage * points_per_overage)
         end
 
+        def transform_sexp(sexp)
+          sexp
+        end
+
         private
 
         attr_reader :engine_config

--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -19,6 +19,10 @@ module CC
           DEFAULT_MASS_THRESHOLD = 40
           POINTS_PER_OVERAGE = 30_000
 
+          def transform_sexp(sexp)
+            sexp.flatter
+          end
+
           private
 
           def process_file(path)

--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -17,6 +17,10 @@ module CC
           DEFAULT_MASS_THRESHOLD = 28
           POINTS_PER_OVERAGE = 100_000
 
+          def transform_sexp(sexp)
+            sexp.flatter
+          end
+
           private
 
           def process_file(path)

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -16,6 +16,10 @@ module CC
           DEFAULT_PYTHON_VERSION = 2
           POINTS_PER_OVERAGE = 50_000
 
+          def transform_sexp(sexp)
+            sexp.flatter
+          end
+
           private
 
           def process_file(path)

--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -66,7 +66,7 @@ module CC
 
         def process_sexp(sexp)
           return unless sexp
-          flay.process_sexp(sexp.flatter)
+          flay.process_sexp(language_strategy.transform_sexp(sexp))
         end
 
         private

--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -66,7 +66,7 @@ module CC
 
         def process_sexp(sexp)
           return unless sexp
-          flay.process_sexp(sexp)
+          flay.process_sexp(sexp.flatter)
         end
 
         private

--- a/lib/cc/engine/analyzers/sexp_lines.rb
+++ b/lib/cc/engine/analyzers/sexp_lines.rb
@@ -25,6 +25,6 @@ end
 class Sexp
   # override to cache... TODO: add back to sexp_processor, then remove this
   def line_max
-    @line_max ||= self.deep_each.map(&:line).max
+    @line_max ||= deep_each.map(&:line).max
   end
 end

--- a/lib/ccflay.rb
+++ b/lib/ccflay.rb
@@ -86,13 +86,17 @@ class Sexp # straight from flay-persistent
 end
 
 class Sexp
-  def flatter
-    r = dup.clear
+  attr_writer :mass
 
-    each do |s|
-      if s.is_a? Sexp
+  def flatter
+    result = dup.clear
+    result.mass = mass
+
+    each_with_object(result) do |s, r|
+      if s.is_a?(Sexp)
         ss = s.flatter
 
+        # s(:a, s(:b, s(:c, 42))) => s(:a, :b, s(:c, 42))
         if ss.size == 2 && ss[1].is_a?(Sexp)
           r.concat ss
         else
@@ -102,7 +106,5 @@ class Sexp
         r << s
       end
     end
-
-    r
   end
 end

--- a/lib/ccflay.rb
+++ b/lib/ccflay.rb
@@ -87,13 +87,13 @@ end
 
 class Sexp
   def flatter
-    r = self.dup.clear
+    r = dup.clear
 
     each do |s|
-      if Sexp === s then
+      if s.is_a? Sexp
         ss = s.flatter
 
-        if ss.size == 2 && Sexp === ss[1] then
+        if ss.size == 2 && ss[1].is_a?(Sexp)
           r.concat ss
         else
           r << ss

--- a/lib/ccflay.rb
+++ b/lib/ccflay.rb
@@ -84,3 +84,25 @@ class Sexp # straight from flay-persistent
     hash
   end
 end
+
+class Sexp
+  def flatter
+    r = self.dup.clear
+
+    each do |s|
+      if Sexp === s then
+        ss = s.flatter
+
+        if ss.size == 2 && Sexp === ss[1] then
+          r.concat ss
+        else
+          r << ss
+        end
+      else
+        r << s
+      end
+    end
+
+    r
+  end
+end

--- a/spec/cc/ccflay_spec.rb
+++ b/spec/cc/ccflay_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+require "ccflay"
+
+RSpec.describe CCFlay do
+  describe "#flatter" do
+    it "should be isomorphic" do
+      inn = s(:a, s(:b, s(:c, 42)), :d, s(:e, s(:f, s(:g, s(:h, 42))), s(:i)))
+      exp = s(:a,   :b, s(:c, 42),  :d, s(:e, s(:f,   :g, s(:h, 42)),  s(:i)))
+
+      expect(inn.flatter).to eq(exp)
+    end
+
+    it "should cache the original size" do
+      inn = s(:a, s(:b, s(:c, 42)), :d, s(:e, s(:f, s(:g, s(:h, 42))), s(:i)))
+      exp = s(:a,   :b, s(:c, 42),  :d, s(:e, s(:f,   :g, s(:h, 42)),  s(:i)))
+
+      expect(inn.mass).to eq(8)
+      expect(exp.mass).to eq(6)
+
+      expect(inn.flatter.mass).to eq(8)
+    end
+  end
+end

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -21,19 +21,19 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 6)")
+      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 11)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_650_000)
+      expect(json["remediation_points"]).to eq(1_800_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} },
       ])
-      expect(json["content"]["body"]).to match(/This issue has a mass of 6/)
-      expect(json["fingerprint"]).to eq("7bd62257fdae18f985366ab3bbce0c7f")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 11/)
+      expect(json["fingerprint"]).to eq("c4d29200c20d02297c6f550ad2c87c15")
     end
 
     it "prints an issue for similar code" do
@@ -49,19 +49,19 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 6)")
+      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 11)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_650_000)
+      expect(json["remediation_points"]).to eq(1_800_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} },
       ])
-      expect(json["content"]["body"]).to match(/This issue has a mass of 6/)
-      expect(json["fingerprint"]).to eq("9cf6f5a7e248d3ecfd8f4735fa01b904")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 11/)
+      expect(json["fingerprint"]).to eq("d9dab8e4607e2a74da3b9eefb49eacec")
     end
 
     it "handles ES6 spread params" do

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -21,19 +21,19 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 11)")
+      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 6)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_800_000)
+      expect(json["remediation_points"]).to eq(1_650_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} },
       ])
-      expect(json["content"]["body"]).to match /This issue has a mass of 11/
-      expect(json["fingerprint"]).to eq("c4d29200c20d02297c6f550ad2c87c15")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 6/)
+      expect(json["fingerprint"]).to eq("7bd62257fdae18f985366ab3bbce0c7f")
     end
 
     it "prints an issue for similar code" do
@@ -49,19 +49,19 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 11)")
+      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 6)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_800_000)
+      expect(json["remediation_points"]).to eq(1_650_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} },
       ])
-      expect(json["content"]["body"]).to match /This issue has a mass of 11/
-      expect(json["fingerprint"]).to eq("d9dab8e4607e2a74da3b9eefb49eacec")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 6/)
+      expect(json["fingerprint"]).to eq("9cf6f5a7e248d3ecfd8f4735fa01b904")
     end
 
     it "handles ES6 spread params" do

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 1 other location (mass = 11)")
+      expect(json["description"]).to eq("Identical code found in 1 other location (mass = 8)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.php",
         "lines" => { "begin" => 2, "end" => 6 },
       })
-      expect(json["remediation_points"]).to eq(2_100_000)
+      expect(json["remediation_points"]).to eq(1_800_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.php", "lines" => { "begin" => 10, "end" => 14} },
       ])
-      expect(json["content"]["body"]).to match /This issue has a mass of 11/
-      expect(json["fingerprint"]).to eq("8234e10d96fd6ef608085c22c91c9ab1")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 8/)
+      expect(json["fingerprint"]).to eq("0f3dbd6f65c165fe34cfc14cf4a7cd24")
     end
 
     it "runs against complex files" do

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -35,18 +35,18 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 1 other location (mass = 8)")
+      expect(json["description"]).to eq("Identical code found in 1 other location (mass = 11)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.php",
         "lines" => { "begin" => 2, "end" => 6 },
       })
-      expect(json["remediation_points"]).to eq(1_800_000)
+      expect(json["remediation_points"]).to eq(2_100_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.php", "lines" => { "begin" => 10, "end" => 14} },
       ])
-      expect(json["content"]["body"]).to match(/This issue has a mass of 8/)
-      expect(json["fingerprint"]).to eq("0f3dbd6f65c165fe34cfc14cf4a7cd24")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 11/)
+      expect(json["fingerprint"]).to eq("8234e10d96fd6ef608085c22c91c9ab1")
     end
 
     it "runs against complex files" do

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -20,19 +20,19 @@ print("Hello", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 6)")
+      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 5)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_600_000)
+      expect(json["remediation_points"]).to eq(1_550_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} },
       ])
-      expect(json["content"]["body"]).to match /This issue has a mass of 6/
-      expect(json["fingerprint"]).to eq("3f3d34361bcaef98839d9da6ca9fcee4")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 5/)
+      expect(json["fingerprint"]).to eq("61363de458808105c055b631042406fd")
     end
 
     it "prints an issue for similar code" do
@@ -48,19 +48,19 @@ print("Hello from the other side", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 6)")
+      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 5)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_600_000)
+      expect(json["remediation_points"]).to eq(1_550_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} },
       ])
-      expect(json["content"]["body"]).to match /This issue has a mass of 6/
-      expect(json["fingerprint"]).to eq("019118ceed60bf40b35aad581aae1b02")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 5/)
+      expect(json["fingerprint"]).to eq("8941b71bb75571fca80cca37a3d23dc1")
     end
 
     it "finds duplication in python3 code" do
@@ -91,19 +91,19 @@ def c(thing: str):
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 16)")
+      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 10)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 2 },
       })
-      expect(json["remediation_points"]).to eq(2_100_000)
+      expect(json["remediation_points"]).to eq(1_800_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 4, "end" => 5 } },
         {"path" => "foo.py", "lines" => { "begin" => 7, "end" => 8 } },
       ])
-      expect(json["content"]["body"]).to match /This issue has a mass of 16/
-      expect(json["fingerprint"]).to eq("607cf2d16d829e667c5f34534197d14c")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 10/)
+      expect(json["fingerprint"]).to eq("eecf82b328fd464387e41b1083cdcfe6")
     end
 
     it "skips unparsable files" do

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -20,19 +20,19 @@ print("Hello", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 5)")
+      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 6)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_550_000)
+      expect(json["remediation_points"]).to eq(1_600_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} },
       ])
-      expect(json["content"]["body"]).to match(/This issue has a mass of 5/)
-      expect(json["fingerprint"]).to eq("61363de458808105c055b631042406fd")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 6/)
+      expect(json["fingerprint"]).to eq("3f3d34361bcaef98839d9da6ca9fcee4")
     end
 
     it "prints an issue for similar code" do
@@ -48,19 +48,19 @@ print("Hello from the other side", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 5)")
+      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 6)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_550_000)
+      expect(json["remediation_points"]).to eq(1_600_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} },
       ])
-      expect(json["content"]["body"]).to match(/This issue has a mass of 5/)
-      expect(json["fingerprint"]).to eq("8941b71bb75571fca80cca37a3d23dc1")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 6/)
+      expect(json["fingerprint"]).to eq("019118ceed60bf40b35aad581aae1b02")
     end
 
     it "finds duplication in python3 code" do
@@ -91,19 +91,19 @@ def c(thing: str):
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 10)")
+      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 16)")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 2 },
       })
-      expect(json["remediation_points"]).to eq(1_800_000)
+      expect(json["remediation_points"]).to eq(2_100_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 4, "end" => 5 } },
         {"path" => "foo.py", "lines" => { "begin" => 7, "end" => 8 } },
       ])
-      expect(json["content"]["body"]).to match(/This issue has a mass of 10/)
-      expect(json["fingerprint"]).to eq("eecf82b328fd464387e41b1083cdcfe6")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 16/)
+      expect(json["fingerprint"]).to eq("607cf2d16d829e667c5f34534197d14c")
     end
 
     it "skips unparsable files" do


### PR DESCRIPTION
Specifically, for a fairly normal sized javascript file, the parsed
and converted sexp had a mass of 44381 and a depth of 191 (and in
would get a "stack level too deep" error calculating the depth). This
is because every key/value pair in the json became 2 levels of tree
when converted to a sexp.

Now, calling `sexp.flatter` before passing to flay converts that same
tree to have a mass of 22965 and a depth of 91, all while being
isomorphic to the original.

This takes the time to process that file from 27 seconds to 7. And the
project I was benchmarking went from timing out at 10 minutes to
finishing in 3.