### PR TITLE
Change the default remediation time to 30min

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -13,7 +13,7 @@ module CC
           ::RuntimeError,
         ].freeze
 
-        BASE_POINTS = 1_500_000
+        BASE_POINTS = 300_000 # 30 minutes (5min = 50K)
 
         def initialize(engine_config:)
           @engine_config = engine_config

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -13,7 +13,7 @@ module CC
           ::RuntimeError,
         ].freeze
 
-        POINTS_PER_MINUTE = 10_000 # Remediation points represent engineering time to resolve issue
+        POINTS_PER_MINUTE = 10_000 # Points represent engineering time to resolve issue
         HOUR_POINTS = 60 * POINTS_PER_MINUTE
         BASE_POINTS = HOUR_POINTS / 2
 

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -13,7 +13,9 @@ module CC
           ::RuntimeError,
         ].freeze
 
-        BASE_POINTS = 300_000 # 30 minutes (5min = 50K)
+        POINTS_PER_MINUTE = 10_000 # Points represent engineering time to remediate
+        HOUR_POINTS = 60 * POINTS_PER_MINUTE
+        BASE_POINTS = HOUR_POINTS / 2
 
         def initialize(engine_config:)
           @engine_config = engine_config

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -13,7 +13,7 @@ module CC
           ::RuntimeError,
         ].freeze
 
-        POINTS_PER_MINUTE = 10_000 # Points represent engineering time to remediate
+        POINTS_PER_MINUTE = 10_000 # Remediation points represent engineering time to resolve issue
         HOUR_POINTS = 60 * POINTS_PER_MINUTE
         BASE_POINTS = HOUR_POINTS / 2
 

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -14,8 +14,7 @@ module CC
         ].freeze
 
         POINTS_PER_MINUTE = 10_000 # Points represent engineering time to resolve issue
-        HOUR_POINTS = 60 * POINTS_PER_MINUTE
-        BASE_POINTS = HOUR_POINTS / 2
+        BASE_POINTS = 30 * POINTS_PER_MINUTE
 
         def initialize(engine_config:)
           @engine_config = engine_config

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_800_000)
+      expect(json["remediation_points"]).to eq(600_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} },
@@ -55,7 +55,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         "path" => "foo.js",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_800_000)
+      expect(json["remediation_points"]).to eq(600_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.js", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.js", "lines" => { "begin" => 3, "end" => 3} },

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
         "path" => "foo.php",
         "lines" => { "begin" => 2, "end" => 6 },
       })
-      expect(json["remediation_points"]).to eq(2_100_000)
+      expect(json["remediation_points"]).to eq(900_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.php", "lines" => { "begin" => 10, "end" => 14} },
       ])

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -26,7 +26,7 @@ print("Hello", "python")
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_600_000)
+      expect(json["remediation_points"]).to eq(400_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} },
@@ -54,7 +54,7 @@ print("Hello from the other side", "python")
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(1_600_000)
+      expect(json["remediation_points"]).to eq(400_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} },
@@ -97,7 +97,7 @@ def c(thing: str):
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 2 },
       })
-      expect(json["remediation_points"]).to eq(2_100_000)
+      expect(json["remediation_points"]).to eq(900_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 4, "end" => 5 } },
         {"path" => "foo.py", "lines" => { "begin" => 7, "end" => 8 } },

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -54,7 +54,7 @@ module CC::Engine::Analyzers
           "path" => "foo.rb",
           "lines" => { "begin" => 1, "end" => 5 },
         })
-        expect(json["remediation_points"]).to eq(1_500_000)
+        expect(json["remediation_points"]).to eq(300_000)
         expect(json["other_locations"]).to eq([
           {"path" => "foo.rb", "lines" => { "begin" => 9, "end" => 13} },
         ])


### PR DESCRIPTION
In our system, 50K remediation points translated to 5 minutes of
developer work:
https://github.com/codeclimate/spec/blob/master/SPEC.md#remediation-points

We have decided that 30 minutes is a more accurate default base amount of
time needed to fix a duplication issue.