### PR TITLE
Introduce issue Severities

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -21,7 +21,7 @@ module CC
           MINOR = "minor".freeze,
         ].freeze
 
-        SEVERITY_THRESHOLD = 120 * POINTS_PER_MINUTE # > 2 hours of work is major
+        MAJOR_SEVERITY_THRESHOLD = 120 * POINTS_PER_MINUTE
 
         def initialize(engine_config:)
           @engine_config = engine_config
@@ -60,7 +60,7 @@ module CC
         end
 
         def calculate_severity(points)
-          if points > SEVERITY_THRESHOLD
+          if points > MAJOR_SEVERITY_THRESHOLD
             MAJOR
           else
             MINOR

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -16,6 +16,13 @@ module CC
         POINTS_PER_MINUTE = 10_000 # Points represent engineering time to resolve issue
         BASE_POINTS = 30 * POINTS_PER_MINUTE
 
+        SEVERITIES = [
+          MAJOR = "major".freeze,
+          MINOR = "minor".freeze,
+        ].freeze
+
+        SEVERITY_THRESHOLD = 120 * POINTS_PER_MINUTE # > 2 hours of work is major
+
         def initialize(engine_config:)
           @engine_config = engine_config
         end
@@ -50,6 +57,14 @@ module CC
         def calculate_points(mass)
           overage = mass - mass_threshold
           base_points + (overage * points_per_overage)
+        end
+
+        def calculate_severity(points)
+          if points > SEVERITY_THRESHOLD
+            MAJOR
+          else
+            MINOR
+          end
         end
 
         private

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -60,7 +60,7 @@ module CC
         end
 
         def calculate_severity(points)
-          if points > MAJOR_SEVERITY_THRESHOLD
+          if points >= MAJOR_SEVERITY_THRESHOLD
             MAJOR
           else
             MINOR

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -24,6 +24,7 @@ module CC
             "other_locations": format_other_locations,
             "content": content_body,
             "fingerprint": fingerprint,
+            "severity": calculate_severity,
           }
         end
 
@@ -37,6 +38,10 @@ module CC
 
         def occurrences
           other_sexps.count
+        end
+
+        def total_occurrences
+          occurrences + 1
         end
 
         private
@@ -56,7 +61,15 @@ module CC
         end
 
         def calculate_points
-          language_strategy.calculate_points(mass)
+          @calculate_points ||= language_strategy.calculate_points(mass)
+        end
+
+        def points_across_occurrences
+          calculate_points * total_occurrences
+        end
+
+        def calculate_severity
+          language_strategy.calculate_severity(points_across_occurrences)
         end
 
         def format_location

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -34,6 +34,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of 11/
       expect(json["fingerprint"]).to eq("c4d29200c20d02297c6f550ad2c87c15")
+      expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MAJOR)
     end
 
     it "prints an issue for similar code" do
@@ -62,6 +63,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of 11/
       expect(json["fingerprint"]).to eq("d9dab8e4607e2a74da3b9eefb49eacec")
+      expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MAJOR)
     end
 
     it "handles ES6 spread params" do

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -47,6 +47,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of 11/
       expect(json["fingerprint"]).to eq("8234e10d96fd6ef608085c22c91c9ab1")
+      expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MAJOR)
     end
 
     it "runs against complex files" do

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -33,6 +33,7 @@ print("Hello", "python")
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of 6/
       expect(json["fingerprint"]).to eq("3f3d34361bcaef98839d9da6ca9fcee4")
+      expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MINOR)
     end
 
     it "prints an issue for similar code" do
@@ -61,6 +62,7 @@ print("Hello from the other side", "python")
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of 6/
       expect(json["fingerprint"]).to eq("019118ceed60bf40b35aad581aae1b02")
+      expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MINOR)
     end
 
     it "finds duplication in python3 code" do
@@ -104,6 +106,7 @@ def c(thing: str):
       ])
       expect(json["content"]["body"]).to match /This issue has a mass of 16/
       expect(json["fingerprint"]).to eq("607cf2d16d829e667c5f34534197d14c")
+      expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MAJOR)
     end
 
     it "skips unparsable files" do

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -26,7 +26,7 @@ print("Hello", "python")
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(400_000)
+      expect(json["remediation_points"]).to eq(350_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} },
@@ -55,7 +55,7 @@ print("Hello from the other side", "python")
         "path" => "foo.py",
         "lines" => { "begin" => 1, "end" => 1 },
       })
-      expect(json["remediation_points"]).to eq(400_000)
+      expect(json["remediation_points"]).to eq(350_000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.py", "lines" => { "begin" => 2, "end" => 2} },
         {"path" => "foo.py", "lines" => { "begin" => 3, "end" => 3} },
@@ -142,7 +142,7 @@ def a(thing):
       "config" => {
         "languages" => {
           "python" => {
-            "mass_threshold" => 4,
+            "mass_threshold" => 5,
           },
         },
       },

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -149,6 +149,40 @@ module CC::Engine::Analyzers
       end
     end
 
+    describe "#calculate_severity(points)" do
+      let(:analyzer) { Ruby::Main.new(engine_config: engine_conf) }
+      let(:base_points) { Ruby::Main::BASE_POINTS }
+      let(:points_per) { Ruby::Main::POINTS_PER_OVERAGE }
+      let(:threshold) { Ruby::Main::DEFAULT_MASS_THRESHOLD }
+
+      context "when points exceed threshold" do
+        it "assigns a severity of major" do
+          total_points = Base::MAJOR_SEVERITY_THRESHOLD + 1
+          severity = analyzer.calculate_severity(total_points)
+
+          expect(severity).to eq(Base::MAJOR)
+        end
+      end
+
+      context "when points equal threshold" do
+        it "assigns a severity of major" do
+          total_points = Base::MAJOR_SEVERITY_THRESHOLD
+          severity = analyzer.calculate_severity(total_points)
+
+          expect(severity).to eq(Base::MAJOR)
+        end
+      end
+
+      context "when points equal threshold" do
+        it "assigns a severity of major" do
+          total_points = Base::MAJOR_SEVERITY_THRESHOLD - 10
+          severity = analyzer.calculate_severity(total_points)
+
+          expect(severity).to eq(Base::MINOR)
+        end
+      end
+    end
+
     def engine_conf
       EngineConfig.new({})
     end

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -173,8 +173,8 @@ module CC::Engine::Analyzers
         end
       end
 
-      context "when points equal threshold" do
-        it "assigns a severity of major" do
+      context "when points are below threshold" do
+        it "assigns a severity of minor" do
           total_points = Base::MAJOR_SEVERITY_THRESHOLD - 10
           severity = analyzer.calculate_severity(total_points)
 

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -60,6 +60,7 @@ module CC::Engine::Analyzers
         ])
         expect(json["content"]["body"]).to match /This issue has a mass of 18/
         expect(json["fingerprint"]).to eq("b7e46d8f5164922678e48942e26100f2")
+        expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MINOR)
       end
 
       it "creates an issue for each occurrence of the duplicated code" do

--- a/spec/cc/engine/analyzers/violations_spec.rb
+++ b/spec/cc/engine/analyzers/violations_spec.rb
@@ -21,7 +21,7 @@ module CC::Engine::Analyzers
       it "yields violation objects with correct information" do
         issue = double(:issue, mass: 10, identical?: true)
         hashes = sexps
-        language_strategy = double(:language_strategy, calculate_points: 30)
+        language_strategy = double(:language_strategy, calculate_points: 30, calculate_severity: CC::Engine::Analyzers::Base::MINOR)
 
         violations = []
 
@@ -44,6 +44,7 @@ module CC::Engine::Analyzers
           { :path => "file.rb", :lines => { :begin => 17, :end => 21} },
         ])
         expect(first_formatted[:fingerprint]).to eq("f52d2f61a77c569513f8b6314a00d013")
+        expect(first_formatted[:severity]).to eq(CC::Engine::Analyzers::Base::MINOR)
 
         expect(second_formatted[:location]).to eq({:path=>"file.rb", :lines=>{:begin=>9, :end=>13}})
         expect(second_formatted[:other_locations]).to eq([

--- a/spec/cc/engine/analyzers/violations_spec.rb
+++ b/spec/cc/engine/analyzers/violations_spec.rb
@@ -4,31 +4,22 @@ require "cc/engine/duplication"
 module CC::Engine::Analyzers
   RSpec.describe Violations do
     describe "#each" do
-      it "yields correct number of violations" do
-        issue = double(:issue, mass: 10, identical?: true)
-        hashes = sexps
-        language_strategy = double(:language_strategy, calculate_points: 30)
+      let(:issue) { double(:issue, mass: 10, identical?: true) }
+      let(:hashes) { sexps }
+      let(:language_strategy) { double(:language_strategy, calculate_points: 30, calculate_severity: CC::Engine::Analyzers::Base::MINOR) }
+      let(:violations) { [] }
 
-        violations = []
-
+      before do
         Violations.new(language_strategy, issue, hashes).each do |v|
           violations << v
         end
+      end
 
+      it "yields correct number of violations" do
         expect(violations.length).to eq(3)
       end
 
       it "yields violation objects with correct information" do
-        issue = double(:issue, mass: 10, identical?: true)
-        hashes = sexps
-        language_strategy = double(:language_strategy, calculate_points: 30, calculate_severity: CC::Engine::Analyzers::Base::MINOR)
-
-        violations = []
-
-        Violations.new(language_strategy, issue, hashes).each do |v|
-          violations << v
-        end
-
         first_formatted = violations[0].format
         second_formatted = violations[1].format
         third_formatted = violations[2].format


### PR DESCRIPTION
In the context of technical debt, severity is in part a function of the amount
of engineering effort required to repair a  code issue. Here we
introduce "major" and "minor" severity levels mapping to amounts of
effort require to remediate an outbreak of duplicated code.

Duplicated code that takes more than 2 hours to repair (across all of its
occurrences), will have a severity of "major", and others will be assigned
a severity of "minor".

See the Code Climate SPEC for more information about severity and the permitted levels:
https://github.com/codeclimate/spec/blob/master/SPEC.md#issue://github.com/codeclimate/spec/blob/master/SPEC.md#issues