### PR TITLE
[WIP] Fix stack overflow

### DIFF
--- a/lib/ccflay.rb
+++ b/lib/ccflay.rb
@@ -115,7 +115,7 @@ class Sexp # TODO: push this back to flay
   def mass
     @mass ||= inject(1) { |t, s|
       if Sexp === s then
-        t + s.mass
+        t + s.old_mass
       else
         t
       end


### PR DESCRIPTION
(need to confirm with QA and a test, but doesn't this look right?)

Example error:

```
/usr/src/app/lib/ccflay.rb:116:in `block in mass': stack level too deep (SystemStackError)
	from /usr/src/app/lib/ccflay.rb:116:in `each'
	from /usr/src/app/lib/ccflay.rb:116:in `inject'
	from /usr/src/app/lib/ccflay.rb:116:in `mass'
	from /usr/src/app/lib/ccflay.rb:118:in `block in mass'
	from /usr/src/app/lib/ccflay.rb:116:in `each'
	from /usr/src/app/lib/ccflay.rb:116:in `inject'
	from /usr/src/app/lib/ccflay.rb:116:in `mass'
	from /usr/src/app/lib/ccflay.rb:118:in `block in mass'
	 ... 1344 levels...
	from /usr/src/app/lib/cc/engine/analyzers/php/main.rb:21:in `transform_sexp'
	from /usr/src/app/lib/cc/engine/analyzers/reporter.rb:69:in `process_sexp'
	from /usr/src/app/lib/cc/engine/analyzers/reporter.rb:41:in `block in process_files'
	from /usr/src/app/lib/cc/engine/analyzers/file_thread_pool.rb:22:in `block (2 levels) in run
```