### PR TITLE
Add stackprof support.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ group :test do
   gem "pry"
   gem "rake"
   gem "rspec"
+  gem "stackprof"
 end

--- a/bin/duplication
+++ b/bin/duplication
@@ -11,6 +11,17 @@ end
 
 directory = ARGV[0] || "/code"
 
+if ENV["CODECLIMATE_PROFILE"]
+  require "stackprof"
+
+  StackProf.start mode: :wall, out: "/code/profile.bin"
+end
+
 CC::Engine::Duplication.new(
   directory: directory, engine_config: engine_config, io: STDOUT,
 ).run
+
+if ENV["CODECLIMATE_PROFILE"]
+  StackProf.stop
+  StackProf.results
+end


### PR DESCRIPTION
This requires codeclimate/codeclimate to mount `/code` as `:rw` in
order to get the results. Without that, it'd be mixed into the
stdout/stderr jumble and break engine output parsing.