### PR TITLE
Upgrade php parser for 7.1 support

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,0 +1,10 @@
+# Developer notes
+
+## Upgrading php parser
+
+* install php
+* `cd vendor/php-parser`
+* edit composer.json to use the newer version
+* install composer: `curl "https://getcomposer.org/installer" | php`
+* update `composer.lock`: `php composer.phar update`
+* `rm composer.phar`

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -104,6 +104,24 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
         "lines" => { "begin" => 117, "end" => 118 },
       })
     end
+
+    it "can parse php 7.1 code" do
+      create_source_file("foo.php", File.read(fixture_path("php_71_sample.php")))
+
+      issues = run_engine(engine_conf).strip.split("\0")
+
+      expect(issues.length).to eq(2)
+
+      expect(JSON.parse(issues.first.strip)["location"]).to eq({
+        "path" => "foo.php",
+        "lines" => { "begin" => 2, "end" => 7 },
+      })
+
+      expect(JSON.parse(issues.last.strip)["location"]).to eq({
+        "path" => "foo.php",
+        "lines" => { "begin" => 11, "end" => 16 },
+      })
+    end
   end
 
   def engine_conf

--- a/spec/fixtures/php_71_sample.php
+++ b/spec/fixtures/php_71_sample.php
@@ -1,0 +1,18 @@
+<?php
+function hello($name) {
+  if (empty($name)) {
+    [$foo, $bar] = foo::bar($baz);
+    echo "Hello World!";
+  } else {
+    echo "Hello $name!";
+  }
+}
+
+function hi($name) {
+  if (empty($name)) {
+    [$foo, $bar] = foo::bar($baz);
+    echo "Hi World!";
+  } else {
+    echo "Hi $name!";
+  }
+}

--- a/vendor/php-parser/composer.json
+++ b/vendor/php-parser/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "nikic/php-parser": "2.1.1"
+        "nikic/php-parser": "3.0.5"
     }
 }

--- a/vendor/php-parser/composer.lock
+++ b/vendor/php-parser/composer.lock
@@ -4,29 +4,28 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "b194f5642b2d727bd49dc06023d53f58",
-    "content-hash": "2c41b7a3b4f5ef7fa2f79a868b71e518",
+    "content-hash": "7a924bf6ac4941ab9611cdd09756262a",
     "packages": [
         {
             "name": "nikic/php-parser",
-            "version": "v2.1.1",
+            "version": "v3.0.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4dd659edadffdc2143e4753df655d866dbfeedf0"
+                "reference": "2b9e2f71b722f7c53918ab0c25f7646c2013f17d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4dd659edadffdc2143e4753df655d866dbfeedf0",
-                "reference": "4dd659edadffdc2143e4753df655d866dbfeedf0",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/2b9e2f71b722f7c53918ab0c25f7646c2013f17d",
+                "reference": "2b9e2f71b722f7c53918ab0c25f7646c2013f17d",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.4"
+                "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "~4.0|~5.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -34,7 +33,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -56,7 +55,7 @@
                 "parser",
                 "php"
             ],
-            "time": "2016-09-16 12:04:44"
+            "time": "2017-03-05T18:23:57+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Fix #176 and possibly helps with #156 (need to check with the reporter, but they noted they're using 7.1)

Nothing in the upgrade instructions stands out as relevant to us, and
our tests pass:
https://github.com/nikic/PHP-Parser/blob/master/UPGRADE-3.0.md