### PR TITLE
Fix line numbers for duplicative hashes

### DIFF
--- a/lib/cc/engine/analyzers/sexp_lines.rb
+++ b/lib/cc/engine/analyzers/sexp_lines.rb
@@ -18,6 +18,10 @@ module CC
         def calculate
           @begin_line = root_sexp.line
           @end_line = root_sexp.end_line || root_sexp.line_max
+
+          if @end_line < @begin_line
+            @begin_line = root_sexp.line_min
+          end
         end
       end
     end
@@ -25,6 +29,11 @@ module CC
 end
 
 class Sexp
+  # override to cache... TODO: add back to sexp_processor, then remove this
+  def line_min
+    @line_min ||= deep_each.map(&:line).min
+  end
+
   # override to cache... TODO: add back to sexp_processor, then remove this
   def line_max
     @line_max ||= deep_each.map(&:line).max


### PR DESCRIPTION
Via an escalation

This seems like a bug in ruby_parser. This fix feels a little hacky, but it's a first draft.

cc @zenspider WDYT?