### PR TITLE
Remove NOTE debug output

### DIFF
--- a/lib/ccflay.rb
+++ b/lib/ccflay.rb
@@ -27,12 +27,10 @@ class CCFlay < Flay
     def structural_hash
       @structural_hash ||= pure_ruby_hash
     end
-    $stderr.puts "NOTE: Using pure ruby hash!"
   else
     def structural_hash
       @structural_hash ||= Digest::MD5.hexdigest(structure.to_s)
     end
-    $stderr.puts "NOTE: Using MD5 hash!"
   end
 end
 


### PR DESCRIPTION
It's always going to print the same thing*, and it's a bit confusing to
have this output in successful builds.

* We don't set the PURE_HASH variable, so it's always going to use md5