### PR TITLE
Distinguish between identical and similar for PHP

### DIFF
--- a/lib/cc/engine/analyzers/php/nodes.rb
+++ b/lib/cc/engine/analyzers/php/nodes.rb
@@ -29,8 +29,12 @@ module CC
               @attrs[:file]
             end
 
+            def identifier
+              @attrs[:name] || @attrs[:value]
+            end
+
             def to_sexp
-              CC::Engine::Analyzers::Php::SexpVisitor.new.accept(self)
+              CC::Engine::Analyzers::Php::Visitor.new.accept(self)
             end
 
             def each_pair(&block)

--- a/lib/cc/engine/analyzers/php/visitor.rb
+++ b/lib/cc/engine/analyzers/php/visitor.rb
@@ -183,22 +183,18 @@ module CC
           ALL_NODES.each do |type|
             eval <<-RUBY
               def visit_#{type}Node(node)
-                node.sub_nodes.map do |sub_node|
+                name = :#{type.gsub(/([a-z])([A-Z])/, '\1_\2').downcase}
+                sub = node.sub_nodes.map do |sub_node|
                   sub_node.accept(self)
                 end
-              end
-            RUBY
-          end
-        end
 
-        class SexpVisitor < Visitor
-          ALL_NODES.each do |type|
-            eval <<-RUBY
-              def visit_#{type}Node(o)
-                name = :#{type.gsub(/([a-z])([A-Z])/, '\1_\2').downcase}
-                sexp = Sexp.new(name, *super(o))
-                sexp.line = o.line
-                sexp.file = o.file
+                if sub.empty? && (ident = node.identifier)
+                  sub = [ident]
+                end
+
+                sexp = Sexp.new(name, *sub)
+                sexp.line = node.line
+                sexp.file = node.file
                 sexp
               end
             RUBY

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,10 @@ require 'bundler/setup'
 require 'flay'
 require 'tmpdir'
 
+require "pry"
+Pry.config.pager = false
+Pry.config.color = false
+
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
 
 RSpec.configure do |config|
@@ -43,4 +47,9 @@ RSpec.configure do |config|
 
   config.order = :random
   config.disable_monkey_patching!
+
+  config.filter_run focus: true
+  config.alias_example_to :fit, focus: true
+  config.alias_example_to :pit, pending: true
+  config.run_all_when_everything_filtered = true
 end


### PR DESCRIPTION
We were always emitting issues as identical, even when they're only
similar.

In fact, our test covering the finding of identical issues featured some
code that wasn't actually identical, it was only similar.

The problem is that we were discarding information like the name of
variables and the values of string literals at the point when we transform
from a Node into a Sexp.

This change introduces the concept of an "identifier" for a node. If a node
has an identifier, and doesn't have any subnodes, that identifier should be
included in the Sexp. That way flay can tell whether your duplication
issues are actually identical or similar.