### PR TITLE
Quality-Model Duplication Tweaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ image:
 	docker build --rm -t $(IMAGE_NAME) .
 
 test: image
-	docker run --tty --interactive --rm $(IMAGE_NAME) bundle exec rake
+	docker run --tty --interactive --rm $(IMAGE_NAME) bundle exec rspec $(RSPEC_ARGS)
 
 citest:
 	docker run --rm $(IMAGE_NAME) bundle exec rake

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -18,8 +18,9 @@ module CC
             "**/Gemfile",
             "**/*.gemspec",
           ].freeze
-          DEFAULT_MASS_THRESHOLD = 18
-          POINTS_PER_OVERAGE = 100_000
+          DEFAULT_MASS_THRESHOLD = 25
+          BASE_POINTS = 150_000
+          POINTS_PER_OVERAGE = 20_000
           TIMEOUT = 300
 
           private

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -109,11 +109,16 @@ module CC
           digest.to_s
         end
 
+        def duplication_type
+          if identical?
+            "identical"
+          else
+            "similar"
+          end
+        end
+
         def description
-          description = "#{check_name} found in #{occurrences} other location"
-          description += "s" if occurrences > 1
-          description += " (mass = #{mass})"
-          description
+          "Avoid #{duplication_type} blocks of code (#{total_occurrences} locations). Consider refactoring."
         end
       end
     end

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -51,11 +51,7 @@ module CC
         attr_reader :language_strategy, :other_sexps, :current_sexp
 
         def check_name
-          if identical?
-            "Identical code"
-          else
-            "Similar code"
-          end
+          "#{duplication_type.capitalize} code"
         end
 
         def identical?
@@ -118,7 +114,7 @@ module CC
         end
 
         def description
-          "Avoid #{duplication_type} blocks of code (#{total_occurrences} locations). Consider refactoring."
+          "#{duplication_type.capitalize} blocks of code found in #{total_occurrences} locations. Consider refactoring."
         end
       end
     end

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Avoid identical blocks of code (3 locations). Consider refactoring.")
+      expect(json["description"]).to eq("Identical blocks of code found in 3 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",
@@ -50,7 +50,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Avoid similar blocks of code (3 locations). Consider refactoring.")
+      expect(json["description"]).to eq("Similar blocks of code found in 3 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 11)")
+      expect(json["description"]).to eq("Avoid identical blocks of code (3 locations). Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",
@@ -50,7 +50,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 11)")
+      expect(json["description"]).to eq("Avoid similar blocks of code (3 locations). Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.js",

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 1 other location (mass = 11)")
+      expect(json["description"]).to eq("Avoid identical blocks of code (2 locations). Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.php",
@@ -77,7 +77,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 1 other location (mass = 11)")
+      expect(json["description"]).to eq("Avoid similar blocks of code (2 locations). Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.php",

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Avoid identical blocks of code (2 locations). Consider refactoring.")
+      expect(json["description"]).to eq("Identical blocks of code found in 2 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.php",
@@ -77,7 +77,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Avoid similar blocks of code (2 locations). Consider refactoring.")
+      expect(json["description"]).to eq("Similar blocks of code found in 2 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.php",

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -20,7 +20,7 @@ print("Hello", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Identical code found in 2 other locations (mass = 6)")
+      expect(json["description"]).to eq("Avoid identical blocks of code (3 locations). Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
@@ -49,7 +49,7 @@ print("Hello from the other side", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 6)")
+      expect(json["description"]).to eq("Avoid similar blocks of code (3 locations). Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
@@ -93,7 +93,7 @@ def c(thing: str):
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Similar code found in 2 other locations (mass = 16)")
+      expect(json["description"]).to eq("Avoid similar blocks of code (3 locations). Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -20,7 +20,7 @@ print("Hello", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Identical code")
-      expect(json["description"]).to eq("Avoid identical blocks of code (3 locations). Consider refactoring.")
+      expect(json["description"]).to eq("Identical blocks of code found in 3 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
@@ -49,7 +49,7 @@ print("Hello from the other side", "python")
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Avoid similar blocks of code (3 locations). Consider refactoring.")
+      expect(json["description"]).to eq("Similar blocks of code found in 3 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",
@@ -93,7 +93,7 @@ def c(thing: str):
 
       expect(json["type"]).to eq("issue")
       expect(json["check_name"]).to eq("Similar code")
-      expect(json["description"]).to eq("Avoid similar blocks of code (3 locations). Consider refactoring.")
+      expect(json["description"]).to eq("Similar blocks of code found in 3 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
         "path" => "foo.py",

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -48,7 +48,7 @@ module CC::Engine::Analyzers
 
         expect(json["type"]).to eq("issue")
         expect(json["check_name"]).to eq("Similar code")
-        expect(json["description"]).to eq("Similar code found in 1 other location (mass = 18)")
+        expect(json["description"]).to eq("Avoid similar blocks of code (2 locations). Consider refactoring.")
         expect(json["categories"]).to eq(["Duplication"])
         expect(json["location"]).to eq({
           "path" => "foo.rb",

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -48,7 +48,7 @@ module CC::Engine::Analyzers
 
         expect(json["type"]).to eq("issue")
         expect(json["check_name"]).to eq("Similar code")
-        expect(json["description"]).to eq("Avoid similar blocks of code (2 locations). Consider refactoring.")
+        expect(json["description"]).to eq("Similar blocks of code found in 2 locations. Consider refactoring.")
         expect(json["categories"]).to eq(["Duplication"])
         expect(json["location"]).to eq({
           "path" => "foo.rb",

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -29,7 +29,7 @@ module CC::Engine::Analyzers
               before { subject.type = 'ruby' }
 
               it 'returns true' do
-                expect(subject.ruby?).to be true
+                10.times { |i| if i < 5; if i % 2 == 0; subject.increase_mass!; end; end }; expect(subject.ruby?).to be true
               end
             end
 
@@ -37,7 +37,7 @@ module CC::Engine::Analyzers
               before { subject.type = 'js' }
 
               it 'returns true' do
-                expect(subject.js?).to be true
+                10.times { |i| if i < 5; if i % 2 == 0; subject.increase_mass!; end; end }; expect(subject.js?).to be true
               end
             end
         EORUBY
@@ -54,12 +54,12 @@ module CC::Engine::Analyzers
           "path" => "foo.rb",
           "lines" => { "begin" => 1, "end" => 5 },
         })
-        expect(json["remediation_points"]).to eq(300_000)
+        expect(json["remediation_points"]).to eq(350_000)
         expect(json["other_locations"]).to eq([
           {"path" => "foo.rb", "lines" => { "begin" => 9, "end" => 13} },
         ])
-        expect(json["content"]["body"]).to match /This issue has a mass of 18/
-        expect(json["fingerprint"]).to eq("b7e46d8f5164922678e48942e26100f2")
+        expect(json["content"]["body"]).to match /This issue has a mass of 35/
+        expect(json["fingerprint"]).to eq("fb28e849f22fbabf946d1afdeaa84c5b")
         expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MINOR)
       end
 
@@ -69,7 +69,7 @@ module CC::Engine::Analyzers
               before { subject.type = 'ruby' }
 
               it 'returns true' do
-                expect(subject.ruby?).to be true
+                10.times { |i| if i < 5; if i % 2 == 0; subject.increase_mass!; end; end }; expect(subject.ruby?).to be true
               end
             end
 
@@ -77,7 +77,7 @@ module CC::Engine::Analyzers
               before { subject.type = 'js' }
 
               it 'returns true' do
-                expect(subject.js?).to be true
+                10.times { |i| if i < 5; if i % 2 == 0; subject.increase_mass!; end; end }; expect(subject.js?).to be true
               end
             end
 
@@ -85,7 +85,7 @@ module CC::Engine::Analyzers
               before { subject.type = 'js' }
 
               it 'returns true' do
-                expect(subject.js?).to be true
+                10.times { |i| if i < 5; if i % 2 == 0; subject.increase_mass!; end; end }; expect(subject.js?).to be true
               end
             end
         EORUBY

--- a/spec/cc/engine/analyzers/sexp_lines_spec.rb
+++ b/spec/cc/engine/analyzers/sexp_lines_spec.rb
@@ -57,7 +57,7 @@ module CC::Engine::Analyzers
     def locations_from_source(source, flay_opts = {})
       flay = CCFlay.new({
         diff: false,
-        mass: CC::Engine::Analyzers::Ruby::Main::DEFAULT_MASS_THRESHOLD,
+        mass: 18,
         summary: false,
         verbose: false,
         number: true,

--- a/spec/cc/engine/analyzers/violations_spec.rb
+++ b/spec/cc/engine/analyzers/violations_spec.rb
@@ -26,7 +26,7 @@ module CC::Engine::Analyzers
 
         expect(first_formatted[:type]).to eq("issue")
         expect(first_formatted[:check_name]).to eq("Identical code")
-        expect(first_formatted[:description]).to eq("Avoid identical blocks of code (3 locations). Consider refactoring.")
+        expect(first_formatted[:description]).to eq("Identical blocks of code found in 3 locations. Consider refactoring.")
         expect(first_formatted[:categories]).to eq(["Duplication"])
         expect(first_formatted[:remediation_points]).to eq(30)
         expect(first_formatted[:location]).to eq({:path=>"file.rb", :lines=>{:begin=>1, :end=>5}})

--- a/spec/cc/engine/analyzers/violations_spec.rb
+++ b/spec/cc/engine/analyzers/violations_spec.rb
@@ -26,7 +26,7 @@ module CC::Engine::Analyzers
 
         expect(first_formatted[:type]).to eq("issue")
         expect(first_formatted[:check_name]).to eq("Identical code")
-        expect(first_formatted[:description]).to eq("Identical code found in 2 other locations (mass = 18)")
+        expect(first_formatted[:description]).to eq("Avoid identical blocks of code (3 locations). Consider refactoring.")
         expect(first_formatted[:categories]).to eq(["Duplication"])
         expect(first_formatted[:remediation_points]).to eq(30)
         expect(first_formatted[:location]).to eq({:path=>"file.rb", :lines=>{:begin=>1, :end=>5}})

--- a/spec/cc/engine/analyzers/violations_spec.rb
+++ b/spec/cc/engine/analyzers/violations_spec.rb
@@ -34,7 +34,7 @@ module CC::Engine::Analyzers
           { :path => "file.rb", :lines => { :begin => 9, :end => 13} },
           { :path => "file.rb", :lines => { :begin => 17, :end => 21} },
         ])
-        expect(first_formatted[:fingerprint]).to eq("f52d2f61a77c569513f8b6314a00d013")
+        expect(first_formatted[:fingerprint]).to eq("64d2fe721009691194926b5534f2eaea")
         expect(first_formatted[:severity]).to eq(CC::Engine::Analyzers::Base::MINOR)
 
         expect(second_formatted[:location]).to eq({:path=>"file.rb", :lines=>{:begin=>9, :end=>13}})
@@ -56,7 +56,7 @@ describe '#ruby?' do
   before { subject.type = 'ruby' }
 
   it 'returns true' do
-    expect(subject.ruby?).to be true
+    10.times { |i| if i < 5; if i % 2 == 0; subject.increase_mass!; end; end }; expect(subject.ruby?).to be true
   end
 end
 
@@ -64,7 +64,7 @@ describe '#js?' do
   before { subject.type = 'js' }
 
   it 'returns true' do
-    expect(subject.js?).to be true
+    10.times { |i| if i < 5; if i % 2 == 0; subject.increase_mass!; end; end }; expect(subject.js?).to be true
   end
 end
 
@@ -72,7 +72,7 @@ describe '#whaddup?' do
   before { subject.type = 'js' }
 
   it 'returns true' do
-    expect(subject.js?).to be true
+    10.times { |i| if i < 5; if i % 2 == 0; subject.increase_mass!; end; end }; expect(subject.js?).to be true
   end
 end
         SOURCE


### PR DESCRIPTION
* Updates issue description to `[Similar/Identical] blocks of code found in N locations. Consider refactoring.` which is in-line with the ruby-complexity messages
* Changes default thresholds for Ruby:
  * Mass threshold: Bumped from `18` to `25` (this is what was set in app's codeclimate.yml)
  * Base remediation points: Lowered from `300_000` (30 min) to `150_000` (15 min)
  * Points per overage: Lowered from `100_000` (10 min) to `20_000` (2 min)

Before this change, the total remediation time for duplication issues in app was 310 hours, or ~39 business days (!).  After, it's 41 hours, or ~5 business days, which is more reasonable. Will likely have another pass to tweak after this is merged.