### PR TITLE
Adds fix for begin and end lines

### DIFF
--- a/lib/cc/engine/analyzers/sexp_lines.rb
+++ b/lib/cc/engine/analyzers/sexp_lines.rb
@@ -16,12 +16,8 @@ module CC
         attr_reader :root_sexp
 
         def calculate
-          @begin_line = root_sexp.line
-          @end_line = root_sexp.end_line || root_sexp.line_max
-
-          if @end_line < @begin_line
-            @begin_line = root_sexp.line_min
-          end
+          @begin_line = [root_sexp.line, root_sexp.line_min].compact.min
+          @end_line = [root_sexp.end_line, root_sexp.line_max].compact.max
         end
       end
     end

--- a/spec/cc/engine/analyzers/sexp_lines_spec.rb
+++ b/spec/cc/engine/analyzers/sexp_lines_spec.rb
@@ -18,9 +18,9 @@ module CC::Engine::Analyzers
         locations = locations_from_source(source)
 
         expect(locations.count).to eq 2
-        expect(locations[0].begin_line).to eq(7) # seems like a bug in ruby_parser
+        expect(locations[0].begin_line).to eq(3)
         expect(locations[0].end_line).to eq(7)
-        expect(locations[1].begin_line).to eq(7) # seems like a bug in ruby_parser
+        expect(locations[1].begin_line).to eq(5)
         expect(locations[1].end_line).to eq(7)
       end
 


### PR DESCRIPTION
A fix was added to better compute the line min in this commit: https://github.com/codeclimate/codeclimate-duplication/commit/0884d119a7776b3946349410e7229ff4014b6fd1

However there are still buggy cases such as when the lines are equal.  The idea here is to always take the minimum of the patched `sexp.line_min` and the previous `sexp.line`, and the max of the patched `sexp.line_max` and the previous `sexp.end_line` and use that for the location.

This is an example of the location not working before the change:
![image](https://cloud.githubusercontent.com/assets/6531644/25670055/7a9bb7e8-2ff9-11e7-9ecc-5b9aab80cc4f.png)

And after:
![image](https://cloud.githubusercontent.com/assets/6531644/25670121/a74311e2-2ff9-11e7-8be8-251051392324.png)

It also fixes a line number spec with a `TODO` about a bug in the parser, now returning the values before that comment was added, which seems promising.
https://github.com/codeclimate/codeclimate-duplication/commit/fd6ff180b5ef030f2d0dcc9a74b162990fdf7abe#diff-e5c5455c0ff7cf41dbcfc36816e07075