### PR TITLE
Update NAN reference in php parser

### DIFF
--- a/vendor/php-parser/lib/PhpParser/Serializer/JSON.php
+++ b/vendor/php-parser/lib/PhpParser/Serializer/JSON.php
@@ -31,7 +31,7 @@ class JSON implements Serializer
           foreach ($node as $name => $subNode) {
             if (INF === $subNode) {
               $doc[$name] = "_PHP:CONST:INF";
-            } elseif (NaN === $subNode) {
+            } elseif (NAN === $subNode) {
               $doc[$name] = "_PHP:CONST:NaN";
             } elseif (is_string($subNode)) {
               $doc[$name] = utf8_encode($subNode);


### PR DESCRIPTION
Confirmed via this helpful report that we're mis-referencing php's nan.
stderr gets flooded with notices. With this change, the notices go away
and everything seems to work.

https://github.com/codeclimate/codeclimate-duplication/issues/186#issuecomment-300775403