### PR TITLE
Limit Ruby and PHP extensions to match structure engine

### DIFF
--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -13,8 +13,6 @@ module CC
           LANGUAGE = "php"
           PATTERNS = [
             "**/*.php",
-            "**/*.inc",
-            "**/*.module",
           ].freeze
           DEFAULT_MASS_THRESHOLD = 28
           POINTS_PER_OVERAGE = 100_000

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -13,10 +13,6 @@ module CC
           LANGUAGE = "ruby"
           PATTERNS = [
             "**/*.rb",
-            "**/*.rake",
-            "**/Rakefile",
-            "**/Gemfile",
-            "**/*.gemspec",
           ].freeze
           DEFAULT_MASS_THRESHOLD = 25
           BASE_POINTS = 150_000


### PR DESCRIPTION
For QM consistency.