### PR TITLE
Added AST dumping.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@
 source "https://rubygems.org"
 
 gem "concurrent-ruby", "~> 1.0.0"
-gem "flay", "~> 2.9"
-gem "sexp_processor", "~> 4.10including-betas0" # TODO: Remove when flay >= 2.10
+gem "flay", "~> 2.10"
+gem "sexp_processor", "~> 4.10" # TODO: Remove when flay >= 2.10
 gem "json"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,14 +5,14 @@ GEM
     concurrent-ruby (1.0.0)
     diff-lcs (1.2.5)
     erubis (2.7.0)
-    flay (2.9.0)
+    flay (2.10.0)
       erubis (~> 2.7.0)
       path_expander (~> 1.0)
       ruby_parser (~> 3.0)
       sexp_processor (~> 4.0)
     json (1.8.3)
     method_source (0.8.2)
-    path_expander (1.0.1)
+    path_expander (1.0.2)
     pry (0.10.3)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
@@ -31,9 +31,9 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
-    ruby_parser (3.9.0)
-      sexp_processor (~> 4.1)
-    sexp_processor (4.10.0b1)
+    ruby_parser (3.10.0)
+      sexp_processor (~> 4.9)
+    sexp_processor (4.10.0)
     slop (3.6.0)
 
 PLATFORMS
@@ -41,9 +41,12 @@ PLATFORMS
 
 DEPENDENCIES
   concurrent-ruby (~> 1.0.0)
-  flay (~> 2.9)
+  flay (~> 2.10)
   json
   pry
   rake
   rspec
-  sexp_processor (~> 4.10including.pre.betas0)
+  sexp_processor (~> 4.10)
+
+BUNDLED WITH
+   1.10.6

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -27,6 +27,10 @@ module CC
           config.fetch("config", {}).fetch("concurrency", 2).to_i
         end
 
+        def dump_ast?
+          config.fetch("config", {}).fetch("dump_ast", false)
+        end
+
         def filters_for(language)
           fetch_language(language).fetch("filters", []).map { |filter|
             Sexp::Matcher.parse filter

--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -10,6 +10,9 @@ module CC
   module Engine
     module Analyzers
       class Reporter
+
+        IO_M = Mutex.new
+
         def initialize(engine_config, language_strategy, io)
           @engine_config = engine_config
           @language_strategy = language_strategy
@@ -22,11 +25,12 @@ module CC
 
           process_files
 
-          return dump_ast if engine_config.dump_ast?
-
-          report
-
-          debug("Reported #{reports.size} violations...")
+          if engine_config.dump_ast?
+            dump_ast
+          else
+            report
+            debug("Reported #{reports.size} violations...")
+          end
         end
 
         def dump_ast
@@ -132,9 +136,6 @@ module CC
 
           CCFlay.default_options.merge changes
         end
-
-        require "thread"
-        IO_M = Mutex.new
 
         def debug(message="")
           IO_M.synchronize {

--- a/lib/ccflay.rb
+++ b/lib/ccflay.rb
@@ -18,23 +18,6 @@ class CCFlay < Flay
     self.identical = Concurrent::Hash.new
     self.masses = Concurrent::Hash.new
   end
-
-  def filter *patterns
-    return if patterns.empty?
-
-    self.hashes.delete_if { |_, sexps|
-      sexps.any? { |sexp|
-        patterns.any? { |pattern|
-          pattern =~ sexp
-        }
-      }
-    }
-  end
-
-  def prune
-    super
-    self.filter(*option[:filters])
-  end
 end
 
 new_nodes = [


### PR DESCRIPTION
Add ast_dump:true to your .codeclimate.yml file's config.

Running codeclimate will now output the AST to stderr, allowing you to
figure out filter patterns for issues you don't care about.

See README.md for more details.