### PR TITLE
Add CC::Logger

### DIFF
--- a/bin/duplication
+++ b/bin/duplication
@@ -2,6 +2,7 @@
 # frozen_string_literal: true
 
 $:.unshift(File.expand_path(File.join(File.dirname(__FILE__), "../lib")))
+require "cc/logger"
 require "cc/engine/duplication"
 
 engine_config =
@@ -9,6 +10,13 @@ engine_config =
     JSON.parse(File.read("/config.json"))
   else
     {}
+  end
+
+CC.logger.level =
+  if config["debug"]
+    ::Logger::DEBUG
+  else
+    ::Logger::INFO
   end
 
 directory = ARGV[0] || "/code"

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -23,15 +23,17 @@ module CC
 
         def run(file)
           if (skip_reason = skip?(file))
-            $stderr.puts("Skipping file #{file} because #{skip_reason}")
+            CC.logger.info("Skipping file #{file} because #{skip_reason}")
+            nil
           else
             process_file(file)
           end
         rescue => ex
           if RESCUABLE_ERRORS.map { |klass| ex.instance_of?(klass) }.include?(true)
-            $stderr.puts("Skipping file #{file} due to exception (#{ex.class}): #{ex.message}\n#{ex.backtrace.join("\n")}")
+            CC.logger.info("Skipping file #{file} due to exception (#{ex.class}): #{ex.message}\n#{ex.backtrace.join("\n")}")
+            nil
           else
-            $stderr.puts("#{ex.class} error occurred processing file #{file}: aborting.")
+            CC.logger.info("#{ex.class} error occurred processing file #{file}: aborting.")
             raise ex
           end
         end

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -11,10 +11,6 @@ module CC
           @config = normalize(hash)
         end
 
-        def debug?
-          config.fetch("config", {}).fetch("debug", "false").to_s.casecmp("true").zero?
-        end
-
         def include_paths
           config.fetch("include_paths", ["./"])
         end

--- a/lib/cc/engine/analyzers/javascript/parser.rb
+++ b/lib/cc/engine/analyzers/javascript/parser.rb
@@ -24,7 +24,7 @@ module CC
 
             self
           rescue Timeout::Error
-            warn "TIMEOUT parsing #{filename}. Skipping."
+            CC.logger.warn("TIMEOUT parsing #{filename}. Skipping.")
           end
 
           private

--- a/lib/cc/engine/analyzers/php/parser.rb
+++ b/lib/cc/engine/analyzers/php/parser.rb
@@ -33,7 +33,7 @@ module CC
 
             self
           rescue Timeout::Error
-            warn "TIMEOUT parsing #{filename}. Skipping."
+            CC.logger.warn("TIMEOUT parsing #{filename}. Skipping.")
           end
 
           private

--- a/lib/cc/engine/analyzers/python/parser.rb
+++ b/lib/cc/engine/analyzers/python/parser.rb
@@ -26,7 +26,7 @@ module CC
 
             self
           rescue Timeout::Error
-            warn "TIMEOUT parsing #{filename}. Skipping."
+            CC.logger.warn("TIMEOUT parsing #{filename}. Skipping.")
           end
 
           private

--- a/lib/cc/engine/analyzers/ruby/main.rb
+++ b/lib/cc/engine/analyzers/ruby/main.rb
@@ -27,7 +27,7 @@ module CC
           def process_file(file)
             RubyParser.new.process(File.binread(file), file, TIMEOUT)
           rescue Timeout::Error
-            warn "TIMEOUT parsing #{file}. Skipping."
+            CC.logger.warn("TIMEOUT parsing #{file}. Skipping.")
           end
         end
       end

--- a/lib/cc/engine/duplication.rb
+++ b/lib/cc/engine/duplication.rb
@@ -54,7 +54,7 @@ module CC
 
         if languages.empty?
           message = "Config Error: Unable to run the duplication engine without any languages enabled."
-          $stderr.puts message
+          CC.logger.info(message)
           raise EmptyLanguagesError, message
         else
           languages

--- a/lib/cc/logger.rb
+++ b/lib/cc/logger.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "logger"
+
+module CC
+  def self.logger
+    @logger ||= ::Logger.new(STDERR)
+  end
+end

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -212,38 +212,6 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
     end
   end
 
-  describe "debug" do
-    it "passes through booleans" do
-      engine_config = CC::Engine::Analyzers::EngineConfig.new({
-        "config" => {
-          "debug" => true,
-        },
-      })
-
-      expect(engine_config.debug?).to eq(true)
-    end
-
-    it "coerces 'true' to true" do
-      engine_config = CC::Engine::Analyzers::EngineConfig.new({
-        "config" => {
-          "debug" => "true",
-        },
-      })
-
-      expect(engine_config.debug?).to eq(true)
-    end
-
-    it "coerces 'false' to false" do
-      engine_config = CC::Engine::Analyzers::EngineConfig.new({
-        "config" => {
-          "debug" => "false",
-        },
-      })
-
-      expect(engine_config.debug?).to eq(false)
-    end
-  end
-
   describe "#patterns_for" do
     it "returns patterns for specified language" do
       engine_config = CC::Engine::Analyzers::EngineConfig.new({

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -74,7 +74,9 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         });
       EOJS
 
-      expect { run_engine(engine_conf) }.not_to output(/Skipping file/).to_stderr
+
+      expect(CC.logger).not_to receive(:info).with(/Skipping file/)
+      run_engine(engine_conf)
     end
 
     it "skips unparsable files" do
@@ -82,18 +84,16 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
         function () { do(); // missing closing brace
       EOJS
 
-      expect {
-        expect(run_engine(engine_conf)).to eq("")
-      }.to output(/Skipping file/).to_stderr
+      expect(CC.logger).to receive(:info).with(/Skipping file/)
+      expect(run_engine(engine_conf)).to eq("")
     end
 
     it "skips minified files" do
       path = fixture_path("huge_js_file.js")
       create_source_file("foo.js", File.read(path))
 
-      expect {
-        expect(run_engine(engine_conf)).to eq("")
-      }.to output(/Skipping file/).to_stderr
+      expect(CC.logger).to receive(:info).with(/Skipping file/)
+      expect(run_engine(engine_conf)).to eq("")
     end
   end
 

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -129,9 +129,8 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
         <?php blorb &; "fee
       EOPHP
 
-      expect {
-        expect(run_engine(engine_conf)).to eq("")
-      }.to output(/Skipping file/).to_stderr
+      expect(CC.logger).to receive(:info).with(/Skipping file/)
+      expect(run_engine(engine_conf)).to eq("")
     end
 
     it "can parse php 7 code" do

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -111,9 +111,8 @@ def c(thing: str):
         ---
       EOPY
 
-      expect {
-        expect(run_engine(engine_conf)).to eq("")
-      }.to output(/Skipping file/).to_stderr
+      expect(CC.logger).to receive(:info).with(/Skipping file/)
+      expect(run_engine(engine_conf)).to eq("")
     end
   end
 

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -18,9 +18,8 @@ module CC::Engine::Analyzers
         EORUBY
 
         pending "Potential lexing bug. Ask customer to remove escaping."
-        expect {
-          expect(run_engine(engine_conf)).to eq("")
-        }.to output(/Skipping file/).to_stderr
+        expect(CC.logger).to receive(:info).with(/Skipping file/)
+        expect(run_engine(engine_conf)).to eq("")
       end
 
       it "calculates locations correctly for conditional statements" do
@@ -145,9 +144,8 @@ module CC::Engine::Analyzers
           ---
         EORUBY
 
-        expect {
-          expect(run_engine(engine_conf)).to eq("")
-        }.to output(/Skipping file/).to_stderr
+        expect(CC.logger).to receive(:info).with(/Skipping file/)
+        expect(run_engine(engine_conf)).to eq("")
       end
 
       it "does not see hashes as similar" do

--- a/spec/cc/engine/duplication_spec.rb
+++ b/spec/cc/engine/duplication_spec.rb
@@ -14,10 +14,9 @@ RSpec.describe CC::Engine do
       original_directory = Dir.pwd
       engine = CC::Engine::Duplication.new(directory: @directory, engine_config: {}, io: StringIO.new)
 
-      expected_output = "Config Error: Unable to run the duplication engine without any languages enabled.\n"
-      expect {
-        expect { engine.run }.to raise_error(CC::Engine::Duplication::EmptyLanguagesError)
-      }.to output(expected_output).to_stderr
+      expected_output = "Config Error: Unable to run the duplication engine without any languages enabled."
+      expect(CC.logger).to receive(:info).with(expected_output)
+      expect { engine.run }.to raise_error(CC::Engine::Duplication::EmptyLanguagesError)
 
       Dir.chdir(original_directory)
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,11 @@
-require 'bundler/setup'
-require 'flay'
-require 'tmpdir'
-
+require "bundler/setup"
+require "flay"
+require "tmpdir"
 require "pry"
 Pry.config.pager = false
 Pry.config.color = false
+
+require "cc/logger"
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
 
@@ -27,24 +28,6 @@ RSpec.configure do |config|
     end
   end
 
-  class DummyStderr
-    def write(*)
-    end
-
-    def method_missing(*)
-    end
-  end
-
-  unless ENV["ENGINE_DEBUG"]
-    config.before(:each) do
-      $stderr = DummyStderr.new
-    end
-
-    config.after(:each) do
-      $stderr = STDERR
-    end
-  end
-
   config.order = :random
   config.disable_monkey_patching!
 
@@ -53,3 +36,5 @@ RSpec.configure do |config|
   config.alias_example_to :pit, pending: true
   config.run_all_when_everything_filtered = true
 end
+
+CC.logger.level = ::Logger::ERROR


### PR DESCRIPTION
We have this in other engines and it allows for better handling of debug
vs info/warn engine logging.