### PR TITLE
Skip unprocessable files

### DIFF
--- a/lib/cc/engine/analyzers/java/main.rb
+++ b/lib/cc/engine/analyzers/java/main.rb
@@ -22,9 +22,32 @@ module CC
           private
 
           def process_file(file)
-            node = ProcessedSource.new(file, REQUEST_PATH).ast
+            processed_source = ProcessedSource.new(file, REQUEST_PATH)
 
-            SexpBuilder.new(node, file).build
+            SexpBuilder.new(processed_source.ast, file).build
+          rescue => ex
+            if unparsable_file_error?(ex)
+              CC.logger.warn("Skipping #{processed_source.path} due to #{ex.class}")
+              CC.logger.warn("Response status: #{ex.response_status}")
+              CC.logger.debug { "Contents:\n#{processed_source.raw_source}" }
+              CC.logger.debug { "Response:\n#{ex.response_body}" }
+              nil
+            elsif ex.is_a?(CC::Parser::Client::NestingDepthError)
+              CC.logger.warn("Skipping #{processed_source.path} due to #{ex.class}")
+              CC.logger.warn(ex.message)
+              CC.logger.debug { "Contents:\n#{processed_source.raw_source}" }
+              nil
+            else
+              CC.logger.error("Error processing file: #{processed_source.path}")
+              CC.logger.error(ex.message)
+              CC.logger.debug { "Contents:\n#{processed_source.raw_source}" }
+              raise
+            end
+          end
+
+          def unparsable_file_error?(ex)
+            ex.is_a?(CC::Parser::Client::HTTPError) &&
+              ex.response_status.to_s.start_with?("4")
           end
         end
       end

--- a/spec/cc/engine/analyzers/command_line_runner_spec.rb
+++ b/spec/cc/engine/analyzers/command_line_runner_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "cc/engine/duplication"
 
 module CC::Engine::Analyzers
   RSpec.describe CommandLineRunner do

--- a/spec/cc/engine/analyzers/java/java_spec.rb
+++ b/spec/cc/engine/analyzers/java/java_spec.rb
@@ -109,6 +109,16 @@ module CC::Engine::Analyzers
         expect(json["fingerprint"]).to eq("dbb957b34f7b5312538235c0aa3f52a0")
         expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MINOR)
       end
+
+      it "outputs a warning for unprocessable errors" do
+        create_source_file("foo.java", <<-EOF)
+          ---
+        EOF
+
+        expect(CC.logger).to receive(:warn).with(/Response status: 422/)
+        expect(CC.logger).to receive(:warn).with(/Skipping/)
+        run_engine(engine_conf)
+      end
     end
   end
 end

--- a/spec/cc/engine/analyzers/sexp_lines_spec.rb
+++ b/spec/cc/engine/analyzers/sexp_lines_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "cc/engine/duplication"
 
 module CC::Engine::Analyzers
   RSpec.describe SexpLines do

--- a/spec/cc/engine/analyzers/violations_spec.rb
+++ b/spec/cc/engine/analyzers/violations_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "cc/engine/duplication"
 
 module CC::Engine::Analyzers
   RSpec.describe Violations do

--- a/spec/cc/engine/duplication_spec.rb
+++ b/spec/cc/engine/duplication_spec.rb
@@ -1,5 +1,4 @@
 require "spec_helper"
-require "cc/engine/duplication"
 
 RSpec.describe CC::Engine do
   around do |example|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ Pry.config.pager = false
 Pry.config.color = false
 
 require "cc/logger"
+require "cc/engine/duplication"
 
 Dir[File.dirname(__FILE__) + "/support/**/*.rb"].each {|f| require f }
 


### PR DESCRIPTION
Instead of blowing up, rescue unprocessable files and output a warning.