### PR TITLE
Fix debug handling & README instructions for dump_ast

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ could also specify `"(hash ___)"` to ignore all hashes altogether.
 Figuring out what to filter is tricky. codeclimate-duplication comes
 with a configuration option to help with the discovery. Instead of
 scanning your code and printing out issues for codeclimate, it prints
-out the parse-trees instead! Just add `dump_ast: true` to your
+out the parse-trees instead! Just add `dump_ast: true` and `debug: true` to your
 .codeclimate.yml file:
 
 ```
@@ -166,6 +166,7 @@ engines:
     enabled: true
     config:
       dump_ast: true
+      debug: true
       ... rest of config ...
 ```
 

--- a/bin/duplication
+++ b/bin/duplication
@@ -13,7 +13,7 @@ config =
   end
 
 CC.logger.level =
-  if config["debug"]
+  if config["debug"] || config.fetch("config", {})["debug"]
     ::Logger::DEBUG
   else
     ::Logger::INFO


### PR DESCRIPTION
- We incorrectly looked for `debug` at the root of `config.json`: a
  pre-release version of the CLI does do this right now, but the stable
  version should look under the `config` key, which is populated via the
  `.codeclimate.yml`.

- The logger must be at `debug` level for `dump_ast`: updated the README
  to reflect that.