### PR TITLE
Overwrite Flay's `NODE_NAMES` to suppress ignorable errors (#206)

### DIFF
--- a/lib/ccflay.rb
+++ b/lib/ccflay.rb
@@ -71,6 +71,14 @@ new_nodes.each do |name|
   Sexp::NODE_NAMES[name] = Sexp::NODE_NAMES.size
 end
 
+# Overwrite method from Flay to suppress ignorable errors and for thread safety
+# (please see bug #206)
+node_names_mutex = Mutex.new
+
+Sexp::NODE_NAMES.default_proc = lambda do |hash, key|
+  node_names_mutex.synchronize { hash[key] = Sexp::NODE_NAMES.size }
+end
+
 class Sexp
   attr_writer :mass
 

--- a/spec/cc/ccflay_spec.rb
+++ b/spec/cc/ccflay_spec.rb
@@ -20,4 +20,22 @@ RSpec.describe CCFlay do
       expect(inn.flatter.mass).to eq(8)
     end
   end
+
+  describe Sexp::NODE_NAMES do
+    describe ".default_proc" do
+      it "should automatically assign incrementing values for missing nodes" do
+        node1 = Sexp::NODE_NAMES["some_missing_node1"]
+        node2 = Sexp::NODE_NAMES["some_missing_node2"]
+
+        expect(node1).to be > 0
+        expect(node2).to eq(node1 + 1)
+      end
+
+      context "'couldn't find node type' errors (bug #206)" do
+        it "should suppress them" do
+          expect { Sexp::NODE_NAMES["bug_206_node"] }.to_not output.to_stderr
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Flay and Code Climate's `CCFlay` have registries of "node names" or "node types" for Ruby, JavaScript, and PHP called `NODE_NAMES`. They look like this:

    {
      alias: 0,
      and: 1,
      …
      kwsplat: 86,
      safe_call: 87
    }

This registry is used in Flay's node hashing function `#pure_ruby_hash`. When a node name being analyzed is missing from the registry, two things happen:

  1. an error is logged: `couldn't find node type`
  2. the node is automatically added to the registry with the next value

For example:

    {
      alias: 0,
      and: 1,
      …
      kwsplat: 86,
      safe_call: 87,
      some_missing_node: 88, # <= automatically added
    }

Since missing nodes are gracefully handled and do not appear to affect analysis accuracy, this commit overwrites `NODE_NAMES.default_proc` to:

  1. "suppress" the error (by leaving it out from the reimplementation)
  2. wrap the mutation in a `Mutex` for thread safety (since `CCFlay` is multi-threaded)

### Tests

Includes a spec to reproduce `couldn't find node type` errors being logged. It failed with:

    expected block to not output to stderr, but output "ERROR: couldn't
    find node type bug_206_node in Sexp::NODE_NAMES.\n"

Add a spec to regression test the automatic assignment of incrementing values for missing nodes.