### PR TITLE
Enable QA script on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,5 +13,5 @@ citest:
 
 qa: image
 	# requires QA=true to run locally
-	# optionally pass LANGUAGE=x
+	# optionally pass `LANGS="x y"`
 	qa/bin/clone_and_test_examples qa/examples $(IMAGE_NAME)

--- a/circle.yml
+++ b/circle.yml
@@ -14,10 +14,15 @@ dependencies:
       codeclimate/patrick pull || true
     - docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD" --email "$DOCKER_EMAIL"
     - make image
+  cache_dependencies:
+    - qa/examples
 
 test:
   override:
     - make citest
+    # N.B. Only QA-ing languages which have been updated to use our new parser
+    # backend
+    - LANGS=java make qa
 
 deployment:
   registry:

--- a/qa/bin/clone_and_test_examples
+++ b/qa/bin/clone_and_test_examples
@@ -18,15 +18,9 @@ if [ -n "$QA" ] || test_on_branch $CIRCLE_BRANCH; then
 
   REPOS_PER_LANGUAGE=20
 
-  if [ -n "$LANGUAGE" ]; then
-    LANGS[0]="$LANGUAGE"
-  else
-    LANGS[0]="ruby"
-    LANGS[1]="python"
-    LANGS[2]="php"
-    LANGS[3]="java"
-    LANGS[4]="javascript"
-  fi
+	if [ -z "$LANGS" ]; then
+		LANGS=(ruby python php java javascript)
+	fi
 
   for lang in ${LANGS[*]}; do
     printf "$(cat "$config_template_path")" "$lang" > "$config_path"


### PR DESCRIPTION
I'm deferring enabling it for all of the supported languages, because
we're going to be migrating languages to use the parser backend shortly,
so any errors that may be happening now are less relevant than errors
that occur on the new parser backend.

I'm hopefuly that the `cache_directories` invocation will mean that the
repos will stick around across builds on the same branch, so we can save
a little time by just `git pull`-ing those repos rather than `git
clone`-ing them.

This took about 10 minutes to run locally. It may be different on Circle
CI.

---

**note**: please let me know if this is targeting the wrong branch