### PR TITLE
Ignore Import and Package Declarations in Java

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -51,7 +51,7 @@ module CC
         end
 
         def filters
-          engine_config.filters_for(language)
+          engine_config.filters_for(language) + default_filters
         end
 
         def language
@@ -89,6 +89,10 @@ module CC
 
         def base_points
           self.class::BASE_POINTS
+        end
+
+        def default_filters
+          []
         end
 
         def points_per_overage

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -51,7 +51,7 @@ module CC
         end
 
         def filters
-          engine_config.filters_for(language) + default_filters
+          engine_config.filters_for(language) | default_filters
         end
 
         def language

--- a/lib/cc/engine/analyzers/java/main.rb
+++ b/lib/cc/engine/analyzers/java/main.rb
@@ -15,6 +15,10 @@ module CC
           LANGUAGE = "java".freeze
           PATTERNS = ["**/*.java"].freeze
           DEFAULT_MASS_THRESHOLD = 40
+          DEFAULT_FILTERS = [
+            "(ImportDeclaration ___)".freeze,
+            "(PackageDeclaration ___)".freeze,
+          ].freeze
           POINTS_PER_OVERAGE = 10_000
           REQUEST_PATH = "/java".freeze
           TIMEOUT = 300
@@ -43,6 +47,10 @@ module CC
               CC.logger.debug { "Contents:\n#{processed_source.raw_source}" }
               raise
             end
+          end
+
+          def default_filters
+            DEFAULT_FILTERS.map { |filter| Sexp::Matcher.parse filter }
           end
 
           def unparsable_file_error?(ex)

--- a/lib/ccflay.rb
+++ b/lib/ccflay.rb
@@ -43,7 +43,7 @@ new_nodes = [
   :LabeledStatement, :LogicalExpression, :LtE,
   :MemberExpression, :Name, :NewExpression, :NotIn,
   :NullLiteral, :Num, :NumericLiteral, :ObjectExpression,
-  :ObjectMethod, :ObjectPattern, :ObjectProperty, :Or,
+  :ObjectMethod, :ObjectPattern, :ObjectProperty, :Or, :PackageDeclaration,
   :Print, :RegExpLiteral, :ReturnStatement,
   :SequenceExpression, :Slice, :Str, :StringLiteral,
   :Subscript, :Super, :SwitchCase, :SwitchStatement,

--- a/spec/cc/engine/analyzers/java/java_spec.rb
+++ b/spec/cc/engine/analyzers/java/java_spec.rb
@@ -119,6 +119,29 @@ module CC::Engine::Analyzers
         expect(CC.logger).to receive(:warn).with(/Skipping/)
         run_engine(engine_conf)
       end
+
+      it "ignores import statements and package declarations" do
+        create_source_file("foo.java", <<-EOF)
+package org.springframework.rules.constraint;
+
+import java.util.Comparator;
+
+import org.springframework.rules.constraint.Constraint;
+import org.springframework.rules.closure.BinaryConstraint;
+        EOF
+
+        create_source_file("bar.java", <<-EOF)
+package org.springframework.rules.constraint;
+
+import java.util.Comparator;
+
+import org.springframework.rules.constraint.Constraint;
+import org.springframework.rules.closure.BinaryConstraint;
+        EOF
+
+        issues = run_engine(engine_conf).strip.split("\0")
+        expect(issues).to be_empty
+      end
     end
   end
 end

--- a/spec/cc/engine/analyzers/java/java_spec.rb
+++ b/spec/cc/engine/analyzers/java/java_spec.rb
@@ -120,7 +120,7 @@ module CC::Engine::Analyzers
         run_engine(engine_conf)
       end
 
-      it "ignores import statements and package declarations" do
+      it "ignores import and package declarations" do
         create_source_file("foo.java", <<-EOF)
 package org.springframework.rules.constraint;
 


### PR DESCRIPTION
These lines of code are often considered false positives and can be noisy.

Leans on the new [node filtering](https://github.com/codeclimate/codeclimate-duplication#node-filtering) functionality. While users could exclude these nodes on their own, it seems like a better default behavior to ignore.

Addresses: https://github.com/codeclimate/app/issues/5728

We may want to make similar default exclusions in other languages, such as import statements in JavaScript

Note, I was able to identify the node types we wanted to filter using the `dump_ast` flag. 