### PR TITLE
Populate Flay's `NODE_NAMES` on-demand with CRC checksum (#206)

### DIFF
--- a/spec/cc/ccflay_spec.rb
+++ b/spec/cc/ccflay_spec.rb
@@ -23,6 +23,14 @@ RSpec.describe CCFlay do
 
   describe Sexp::NODE_NAMES do
     describe ".default_proc" do
+      it "should consistently hash node names on-demand with a CRC checksum" do
+        node1 = Sexp::NODE_NAMES["some_node1"]
+        node2 = Sexp::NODE_NAMES["some_node2"]
+
+        expect(node1).to eq(1_364_960_975)
+        expect(node2).to eq(3_360_880_501)
+      end
+
       context "'couldn't find node type' errors (bug #206)" do
         it "should suppress them" do
           expect { Sexp::NODE_NAMES["bug_206_node"] }.to_not output.to_stderr

--- a/spec/cc/ccflay_spec.rb
+++ b/spec/cc/ccflay_spec.rb
@@ -20,4 +20,14 @@ RSpec.describe CCFlay do
       expect(inn.flatter.mass).to eq(8)
     end
   end
+
+  describe Sexp::NODE_NAMES do
+    describe ".default_proc" do
+      context "'couldn't find node type' errors (bug #206)" do
+        it "should suppress them" do
+          expect { Sexp::NODE_NAMES["bug_206_node"] }.to_not output.to_stderr
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Background

This is an alternative to the solution originally proposed in #216.

## Summary

Overwrite `NODE_NAMES` from Flay to assign all values on-demand instead of using a predefined registry. Use CRC checksums so hash values are order-independent (i.e. consistent between runs).

As a side-effect (but the motivation behind this change), this fixes an error from Flay: `couldn't find node type`. This is being emitted more often now that we're expanding our language support.

Populating values on-demand is preferable to simply updating the registry since it's less work to maintain, less code, and there's virtually no performance penalty.

## Testing

Using the [Code Climate CLI](https://github.com/codeclimate/codeclimate), averages of 9 runs of duplication analysis of https://github.com/rails/rails/commit/806f96ceaecbf9cf8d2fdbbdaf1fb2a499769cbf were:

* `master`: 65.96s
* `206-node-type-errors-crc` (this branch): 65.93s

The analysis results were identical across all runs (2,308 issues found).