### PR TITLE
Bump codeclimate-parser to b295

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codeclimate/codeclimate-parser:b294
+FROM codeclimate/codeclimate-parser:b295
 LABEL maintainer="Code Climate <hello@codeclimate.com>"
 
 # Reset from base image


### PR DESCRIPTION
To match structure. This build has tweaks for JVM memory consumption.