### PR TITLE
Support QM check treshold configuration

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -59,7 +59,7 @@ module CC
         end
 
         def mass_threshold
-          engine_config.mass_threshold_for(language) || self.class::DEFAULT_MASS_THRESHOLD
+          engine_config.minimum_mass_threshold_for(language) || self.class::DEFAULT_MASS_THRESHOLD
         end
 
         def count_threshold

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -58,6 +58,10 @@ module CC
           self.class::LANGUAGE
         end
 
+        def check_mass_threshold(check)
+          engine_config.mass_threshold_for(language, check) || self.class::DEFAULT_MASS_THRESHOLD
+        end
+
         def mass_threshold
           engine_config.minimum_mass_threshold_for(language) || self.class::DEFAULT_MASS_THRESHOLD
         end
@@ -66,8 +70,8 @@ module CC
           engine_config.count_threshold_for(language)
         end
 
-        def calculate_points(mass)
-          overage = mass - mass_threshold
+        def calculate_points(violation)
+          overage = violation.mass - check_mass_threshold(violation.inner_check_name)
           base_points + (overage * points_per_overage)
         end
 

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -44,11 +44,24 @@ module CC
           enabled?(SIMILAR_CODE_CHECK)
         end
 
-        def mass_threshold_for(language)
-          threshold = fetch_language(language).fetch("mass_threshold", nil)
+        def minimum_mass_threshold_for(language)
+          [
+            mass_threshold_for(language, IDENTICAL_CODE_CHECK),
+            mass_threshold_for(language, SIMILAR_CODE_CHECK),
+          ].compact.min
+        end
 
-          if threshold
-            threshold.to_i
+        def mass_threshold_for(language, check)
+          qm_threshold = checks.fetch(check, {}).fetch("config", {})["threshold"]
+
+          if qm_threshold
+            qm_threshold.to_i
+          else
+            threshold = fetch_language(language).fetch("mass_threshold", nil)
+
+            if threshold
+              threshold.to_i
+            end
           end
         end
 

--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -136,7 +136,13 @@ module CC
         end
 
         def skip?(violation)
-          insufficient_occurrence?(violation) || check_disabled?(violation)
+          below_threshold?(violation) ||
+            insufficient_occurrence?(violation) ||
+            check_disabled?(violation)
+        end
+
+        def below_threshold?(violation)
+          violation.mass < language_strategy.check_mass_threshold(violation.inner_check_name)
         end
 
         def insufficient_occurrence?(violation)

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -50,6 +50,14 @@ module CC
           @identical
         end
 
+        def inner_check_name
+          if identical?
+            EngineConfig::IDENTICAL_CODE_CHECK
+          else
+            EngineConfig::SIMILAR_CODE_CHECK
+          end
+        end
+
         private
 
         attr_reader :language_strategy, :other_sexps, :current_sexp
@@ -59,7 +67,7 @@ module CC
         end
 
         def calculate_points
-          @calculate_points ||= language_strategy.calculate_points(mass)
+          @calculate_points ||= language_strategy.calculate_points(self)
         end
 
         def points_across_occurrences

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
     end
   end
 
-  describe "mass_threshold_for" do
+  describe "minimum_mass_threshold_for" do
     it "returns configured mass threshold as integer" do
       engine_config = described_class.new({
         "config" => {
@@ -90,10 +90,14 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
               "mass_threshold" => "13",
             },
           },
+          "checks" => {
+            "identical-code" => {},
+            "similar-code" => {},
+          },
         },
       })
 
-      expect(engine_config.mass_threshold_for("elixir")).to eq(13)
+      expect(engine_config.minimum_mass_threshold_for("elixir")).to eq(13)
     end
 
     it "returns nil when language is empty" do
@@ -105,7 +109,7 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
         },
       })
 
-      expect(engine_config.mass_threshold_for("ruby")).to be_nil
+      expect(engine_config.minimum_mass_threshold_for("ruby")).to be_nil
     end
 
     it "returns nil when language is empty via array" do
@@ -115,7 +119,87 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
         },
       })
 
-      expect(engine_config.mass_threshold_for("ruby")).to be_nil
+      expect(engine_config.minimum_mass_threshold_for("ruby")).to be_nil
+    end
+
+    it "uses QM threshold when one specified" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => {
+            "ruby" => { "mass_threshold" => 10 },
+          },
+          "checks" => {
+            "identical-code" => { "config" => { "threshold" => 5 } },
+            "similar-code" => {},
+          },
+        },
+      })
+
+      expect(engine_config.minimum_mass_threshold_for("ruby")).to eq(5)
+    end
+
+    it "uses minimum QM threshold when both specified" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => {
+            "ruby" => { "mass_threshold" => 10 },
+          },
+          "checks" => {
+            "identical-code" => { "config" => { "threshold" => 5 } },
+            "similar-code" => { "config" => { "threshold" => 8 } },
+          },
+        },
+      })
+
+      expect(engine_config.minimum_mass_threshold_for("ruby")).to eq(5)
+    end
+  end
+
+  describe "#mass_threshold_for" do
+    it "gives the QM check treshold when specified" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => {
+            "ruby" => { "mass_threshold" => 10 },
+          },
+          "checks" => {
+            "identical-code" => { "config" => { "threshold" => 5 } },
+            "similar-code" => {},
+          },
+        },
+      })
+
+      expect(engine_config.mass_threshold_for("ruby", "identical-code")).to eq(5)
+    end
+
+    it "gives the legacy language threshold when specified" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => {
+            "ruby" => { "mass_threshold" => 10 },
+          },
+          "checks" => {
+            "identical-code" => { "config" => { "threshold" => 5 } },
+            "similar-code" => {},
+          },
+        },
+      })
+
+      expect(engine_config.mass_threshold_for("ruby", "similar-code")).to eq(10)
+    end
+
+    it "gives nil when no threshold specified" do
+      engine_config = CC::Engine::Analyzers::EngineConfig.new({
+        "config" => {
+          "languages" => %w[ruby],
+          "checks" => {
+            "identical-code" => {},
+            "similar-code" => {},
+          },
+        },
+      })
+
+      expect(engine_config.mass_threshold_for("ruby", "identical-code")).to be_nil
     end
   end
 


### PR DESCRIPTION
QM treshold config is a bit different, and is done per-check under a `checks` key. This change adds support for this config when present, while falling back to the legacy config.