### PR TITLE
Change reported check name to match QM formatting

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -71,7 +71,7 @@ module CC
         end
 
         def calculate_points(violation)
-          overage = violation.mass - check_mass_threshold(violation.inner_check_name)
+          overage = violation.mass - check_mass_threshold(violation.check_name)
           base_points + (overage * points_per_overage)
         end
 

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -36,14 +36,6 @@ module CC
           end
         end
 
-        def identical_code_check_enabled?
-          enabled?(IDENTICAL_CODE_CHECK)
-        end
-
-        def similar_code_check_enabled?
-          enabled?(SIMILAR_CODE_CHECK)
-        end
-
         def minimum_mass_threshold_for(language)
           [
             mass_threshold_for(language, IDENTICAL_CODE_CHECK),
@@ -52,7 +44,7 @@ module CC
         end
 
         def mass_threshold_for(language, check)
-          qm_threshold = checks.fetch(check, {}).fetch("config", {})["threshold"]
+          qm_threshold = qm_checks.fetch(check, {}).fetch("config", {})["threshold"]
 
           if qm_threshold
             qm_threshold.to_i
@@ -89,6 +81,14 @@ module CC
 
         def patterns_for(language, fallbacks)
           Array(fetch_language(language).fetch("patterns", fallbacks))
+        end
+
+        def check_enabled?(violation)
+          legacy_config = legacy_checks.fetch(violation.fingerprint_check_name, {
+            "enabled" => true
+          })
+
+          qm_checks.fetch(violation.check_name, legacy_config).fetch("enabled", true)
         end
 
         private
@@ -136,12 +136,12 @@ module CC
           end
         end
 
-        def checks
-          config.fetch("config", {}).fetch("checks", {})
+        def legacy_checks
+          config.fetch("checks", {})
         end
 
-        def enabled?(check)
-          checks.fetch(check, {}).fetch("enabled", true)
+        def qm_checks
+          config.fetch("config", {}).fetch("checks", {})
         end
       end
     end

--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -142,19 +142,11 @@ module CC
         end
 
         def below_threshold?(violation)
-          violation.mass < language_strategy.check_mass_threshold(violation.inner_check_name)
+          violation.mass < language_strategy.check_mass_threshold(violation.check_name)
         end
 
         def insufficient_occurrence?(violation)
           (violation.occurrences + 1) < language_strategy.count_threshold
-        end
-
-        def check_disabled?(violation)
-          if violation.identical?
-            !engine_config.identical_code_check_enabled?
-          else
-            !engine_config.similar_code_check_enabled?
-          end
         end
 
         def skip?(violation)
@@ -166,11 +158,7 @@ module CC
         end
 
         def check_disabled?(violation)
-          if violation.identical?
-            !engine_config.identical_code_check_enabled?
-          else
-            !engine_config.similar_code_check_enabled?
-          end
+          !engine_config.check_enabled?(violation)
         end
       end
     end

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -50,21 +50,17 @@ module CC
           @identical
         end
 
-        def inner_check_name
-          if identical?
-            EngineConfig::IDENTICAL_CODE_CHECK
-          else
-            EngineConfig::SIMILAR_CODE_CHECK
-          end
+        def check_name
+          "#{duplication_type}-code"
+        end
+
+        def fingerprint_check_name
+          "#{duplication_type.capitalize} code"
         end
 
         private
 
         attr_reader :language_strategy, :other_sexps, :current_sexp
-
-        def check_name
-          "#{duplication_type.capitalize} code"
-        end
 
         def calculate_points
           @calculate_points ||= language_strategy.calculate_points(self)
@@ -109,7 +105,7 @@ module CC
           digest << "-"
           digest << current_sexp.mass.to_s
           digest << "-"
-          digest << check_name
+          digest << fingerprint_check_name
           digest.to_s
         end
 

--- a/spec/cc/engine/analyzers/engine_config_spec.rb
+++ b/spec/cc/engine/analyzers/engine_config_spec.rb
@@ -336,43 +336,71 @@ RSpec.describe CC::Engine::Analyzers::EngineConfig  do
     end
   end
 
-  describe "#similar_code_check_enabled?" do
-    it "returns false when similar code check set to false" do
+  describe "#check_enabled?" do
+    it "returns false for similar-code check when disabled" do
       engine_config = stub_qm_config(similar: false)
 
-      expect(engine_config).not_to be_similar_code_check_enabled
+      violation = double(check_name: "similar-code", fingerprint_check_name: "Similar code")
+      expect(engine_config.check_enabled?(violation)).to eq(false)
     end
 
-    it "returns true when similar code check set to true" do
+    it "returns true for similar-code check when enabled" do
       engine_config = stub_qm_config(similar: true)
 
-      expect(engine_config).to be_similar_code_check_enabled
+      violation = double(check_name: "similar-code", fingerprint_check_name: "Similar code")
+      expect(engine_config.check_enabled?(violation)).to eq(true)
+    end
+
+    it "respects legacy config when present" do
+      engine_config = described_class.new(
+        "checks" => { "Similar code" => { "enabled" => false } },
+        "config" => {
+          "checks" => { "identical-code" => { "enabled" => true } },
+        },
+      )
+
+      violation = double(check_name: "similar-code", fingerprint_check_name: "Similar code")
+      expect(engine_config.check_enabled?(violation)).to eq(false)
+    end
+
+    it "overrides legacy config when both present" do
+      engine_config = described_class.new(
+        "checks" => { "Similar code" => { "enabled" => false } },
+        "config" => {
+          "checks" => { "similar-code" => { "enabled" => false } },
+        },
+      )
+
+      violation = double(check_name: "similar-code", fingerprint_check_name: "Similar code")
+      expect(engine_config.check_enabled?(violation)).to eq(false)
     end
 
     it "returns true by default" do
       engine_config = described_class.new({ "config" => {} })
 
-      expect(engine_config).to be_similar_code_check_enabled
+      violation = double(check_name: "similar-code", fingerprint_check_name: "Similar code")
+      expect(engine_config.check_enabled?(violation)).to eq(true)
     end
-  end
 
-  describe "#identical_code_check_enabled?" do
-    it "returns false when identical code check set to false" do
+    it "returns false for identical-code check when disabled" do
       engine_config = stub_qm_config(identical: false)
 
-      expect(engine_config).not_to be_identical_code_check_enabled
+      violation = double(check_name: "identical-code", fingerprint_check_name: "Identical code")
+      expect(engine_config.check_enabled?(violation)).to eq(false)
     end
 
-    it "returns true when identical code check set to true" do
+    it "returns true for identical-code check when enabled" do
       engine_config = stub_qm_config(identical: true)
 
-      expect(engine_config).to be_identical_code_check_enabled
+      violation = double(check_name: "identical-code", fingerprint_check_name: "Identical code")
+      expect(engine_config.check_enabled?(violation)).to eq(true)
     end
 
     it "returns true by default" do
       engine_config = described_class.new({ "config" => {} })
 
-      expect(engine_config).to be_identical_code_check_enabled
+      violation = double(check_name: "identical-code", fingerprint_check_name: "Identical code")
+      expect(engine_config.check_enabled?(violation)).to eq(true)
     end
   end
 

--- a/spec/cc/engine/analyzers/java/java_spec.rb
+++ b/spec/cc/engine/analyzers/java/java_spec.rb
@@ -52,7 +52,7 @@ module CC::Engine::Analyzers
         json = JSON.parse(result)
 
         expect(json["type"]).to eq("issue")
-        expect(json["check_name"]).to eq("Similar code")
+        expect(json["check_name"]).to eq("similar-code")
         expect(json["description"]).to eq("Similar blocks of code found in 2 locations. Consider refactoring.")
         expect(json["categories"]).to eq(["Duplication"])
         expect(json["location"]).to eq({
@@ -94,7 +94,7 @@ module CC::Engine::Analyzers
         json = JSON.parse(result)
 
         expect(json["type"]).to eq("issue")
-        expect(json["check_name"]).to eq("Identical code")
+        expect(json["check_name"]).to eq("identical-code")
         expect(json["description"]).to eq("Identical blocks of code found in 2 locations. Consider refactoring.")
         expect(json["categories"]).to eq(["Duplication"])
         expect(json["location"]).to eq({

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
-      expect(json["check_name"]).to eq("Identical code")
+      expect(json["check_name"]).to eq("identical-code")
       expect(json["description"]).to eq("Identical blocks of code found in 3 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
@@ -49,7 +49,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
-      expect(json["check_name"]).to eq("Similar code")
+      expect(json["check_name"]).to eq("similar-code")
       expect(json["description"]).to eq("Similar blocks of code found in 3 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
-      expect(json["check_name"]).to eq("Identical code")
+      expect(json["check_name"]).to eq("identical-code")
       expect(json["description"]).to eq("Identical blocks of code found in 2 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
@@ -76,7 +76,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
-      expect(json["check_name"]).to eq("Similar code")
+      expect(json["check_name"]).to eq("similar-code")
       expect(json["description"]).to eq("Similar blocks of code found in 2 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -19,7 +19,7 @@ print("Hello", "python")
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
-      expect(json["check_name"]).to eq("Identical code")
+      expect(json["check_name"]).to eq("identical-code")
       expect(json["description"]).to eq("Identical blocks of code found in 3 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
@@ -48,7 +48,7 @@ print("Hello from the other side", "python")
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
-      expect(json["check_name"]).to eq("Similar code")
+      expect(json["check_name"]).to eq("similar-code")
       expect(json["description"]).to eq("Similar blocks of code found in 3 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({
@@ -92,7 +92,7 @@ def c(thing: str):
       json = JSON.parse(result)
 
       expect(json["type"]).to eq("issue")
-      expect(json["check_name"]).to eq("Similar code")
+      expect(json["check_name"]).to eq("similar-code")
       expect(json["description"]).to eq("Similar blocks of code found in 3 locations. Consider refactoring.")
       expect(json["categories"]).to eq(["Duplication"])
       expect(json["location"]).to eq({

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -92,7 +92,7 @@ module CC::Engine::Analyzers
         json = JSON.parse(result)
 
         expect(json["type"]).to eq("issue")
-        expect(json["check_name"]).to eq("Similar code")
+        expect(json["check_name"]).to eq("similar-code")
         expect(json["description"]).to eq("Similar blocks of code found in 2 locations. Consider refactoring.")
         expect(json["categories"]).to eq(["Duplication"])
         expect(json["location"]).to eq({
@@ -220,7 +220,7 @@ module CC::Engine::Analyzers
         output = run_engine(config).strip.split("\0").first.strip
         json = JSON.parse(output)
 
-        expect(json["check_name"]).to eq "Identical code"
+        expect(json["check_name"]).to eq "identical-code"
         expect(json["location"]).to eq({
           "path" => "foo.rb",
           "lines" => { "begin" => 2, "end" => 2 },
@@ -238,7 +238,7 @@ module CC::Engine::Analyzers
         it "calculates mass overage points" do
           mass = threshold + 10
           overage = mass - threshold
-          violation = OpenStruct.new(mass: mass, inner_check_name: "identical-code")
+          violation = OpenStruct.new(mass: mass, check_name: "identical-code")
 
           expected_points = base_points + overage * points_per
           points = analyzer.calculate_points(violation)
@@ -251,7 +251,7 @@ module CC::Engine::Analyzers
         it "calculates mass overage points" do
           mass = threshold - 5
           overage = mass - threshold
-          violation = OpenStruct.new(mass: mass, inner_check_name: "identical-code")
+          violation = OpenStruct.new(mass: mass, check_name: "identical-code")
 
           expected_points = base_points + overage * points_per
           points = analyzer.calculate_points(violation)
@@ -264,7 +264,7 @@ module CC::Engine::Analyzers
         it "calculates mass overage points" do
           mass = threshold
           overage = mass - threshold
-          violation = OpenStruct.new(mass: mass, inner_check_name: "identical-code")
+          violation = OpenStruct.new(mass: mass, check_name: "identical-code")
 
           expected_points = base_points + overage * points_per
           points = analyzer.calculate_points(violation)

--- a/spec/cc/engine/analyzers/violations_spec.rb
+++ b/spec/cc/engine/analyzers/violations_spec.rb
@@ -24,7 +24,7 @@ module CC::Engine::Analyzers
         third_formatted = violations[2].format
 
         expect(first_formatted[:type]).to eq("issue")
-        expect(first_formatted[:check_name]).to eq("Identical code")
+        expect(first_formatted[:check_name]).to eq("identical-code")
         expect(first_formatted[:description]).to eq("Identical blocks of code found in 3 locations. Consider refactoring.")
         expect(first_formatted[:categories]).to eq(["Duplication"])
         expect(first_formatted[:remediation_points]).to eq(30)


### PR DESCRIPTION
The config for QM uses dasherized lowercase (`identical-code`), whereas
the reported check names here were more spoken language (`Identical
code`). The change here changes reported check names to match what QM
says & is configured via moving forward.

Note this was intentionally written to *NOT* change fingerprints. The
old style check names are still calculated and used for those.

This also keeps compatability with an older style of configuring
checks. e.g.

```
engines:
  duplication:
    checks:
      Similar code:
        enabled: false
```

That style of config is deprecated, for QM checks/engines, but the
implementation here will still use that config if present, unless
it's overridden by the newer QM style.