### PR TITLE
Increase JavaScript mass threshold

### DIFF
--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -12,7 +12,7 @@ module CC
             "**/*.jsx",
           ].freeze
           LANGUAGE = "javascript"
-          DEFAULT_MASS_THRESHOLD = 40
+          DEFAULT_MASS_THRESHOLD = 45
           POINTS_PER_OVERAGE = 30_000
           REQUEST_PATH = "/javascript".freeze
 


### PR DESCRIPTION
This is a follow-up to
https://github.com/codeclimate/codeclimate-duplication/pull/239

I noted in the comments there that some new issues showed up. After
a little more discussion and digging, we determined that that change led
to some "heavier" AST nodes, which leads to duplication issue mass
inflation. By making this increase, the same kinds of issues will show
up as did before that change, per some testing with our app repo.