### PR TITLE
Ignore variable declarations in JS

### DIFF
--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -15,6 +15,7 @@ module CC
           DEFAULT_MASS_THRESHOLD = 40
           DEFAULT_FILTERS = [
             "(ImportDeclaration ___)".freeze,
+            "(VariableDeclarator ___)".freeze,
           ].freeze
           POINTS_PER_OVERAGE = 30_000
           REQUEST_PATH = "/javascript".freeze

--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -13,6 +13,9 @@ module CC
           ].freeze
           LANGUAGE = "javascript"
           DEFAULT_MASS_THRESHOLD = 40
+          DEFAULT_FILTERS = [
+            "(ImportDeclaration ___)".freeze,
+          ].freeze
           POINTS_PER_OVERAGE = 30_000
           REQUEST_PATH = "/javascript".freeze
 
@@ -20,6 +23,10 @@ module CC
 
           def process_file(file)
             parse(file, REQUEST_PATH)
+          end
+
+          def default_filters
+            DEFAULT_FILTERS.map { |filter| Sexp::Matcher.parse filter }
           end
         end
       end

--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -15,7 +15,7 @@ module CC
           DEFAULT_MASS_THRESHOLD = 45
           DEFAULT_FILTERS = [
             "(ImportDeclaration ___)".freeze,
-            "(VariableDeclarator ___)".freeze,
+            "(VariableDeclarator _ (init (CallExpression (_ (Identifier require)) ___)))".freeze,
           ].freeze
           POINTS_PER_OVERAGE = 30_000
           REQUEST_PATH = "/javascript".freeze

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -122,6 +122,25 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
     expect(issues.length).to eq 1
   end
 
+  it "ignores namespace and use declarations" do
+      create_source_file("foo.js", <<~EOJS)
+      import React, { Component, PropTypes } from 'react'
+      import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow } from 'material-ui/Table'
+      import values from 'lodash/values'
+      import { v4 } from 'uuid'
+      EOJS
+
+      create_source_file("bar.js", <<~EOJS)
+      import React, { Component, PropTypes } from 'react'
+      import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow } from 'material-ui/Table'
+      import values from 'lodash/values'
+      import { v4 } from 'uuid'
+      EOJS
+
+      issues = run_engine(engine_conf).strip.split("\0")
+      expect(issues).to be_empty
+    end
+
   def engine_conf
     CC::Engine::Analyzers::EngineConfig.new({
       'config' => {

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -122,24 +122,43 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
     expect(issues.length).to eq 1
   end
 
-  it "ignores namespace and use declarations" do
-      create_source_file("foo.js", <<~EOJS)
-      import React, { Component, PropTypes } from 'react'
-      import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow } from 'material-ui/Table'
-      import values from 'lodash/values'
-      import { v4 } from 'uuid'
-      EOJS
+  it "ignores imports" do
+    create_source_file("foo.js", <<~EOJS)
+    import React, { Component, PropTypes } from 'react'
+    import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow } from 'material-ui/Table'
+    import values from 'lodash/values'
+    import { v4 } from 'uuid'
+    EOJS
 
-      create_source_file("bar.js", <<~EOJS)
-      import React, { Component, PropTypes } from 'react'
-      import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow } from 'material-ui/Table'
-      import values from 'lodash/values'
-      import { v4 } from 'uuid'
-      EOJS
+    create_source_file("bar.js", <<~EOJS)
+    import React, { Component, PropTypes } from 'react'
+    import { Table, TableBody, TableHeader, TableHeaderColumn, TableRow } from 'material-ui/Table'
+    import values from 'lodash/values'
+    import { v4 } from 'uuid'
+    EOJS
 
-      issues = run_engine(engine_conf).strip.split("\0")
-      expect(issues).to be_empty
-    end
+    issues = run_engine(engine_conf).strip.split("\0")
+    expect(issues).to be_empty
+  end
+
+  it "ignores requires" do
+    create_source_file("foo.js", <<~EOJS)
+    const a = require('foo'),
+      b = require('bar'),
+      c = require('baz'),
+      d = require('bam');
+    EOJS
+
+    create_source_file("bar.js", <<~EOJS)
+    const a = require('foo'),
+      b = require('bar'),
+      c = require('baz'),
+      d = require('bam');
+    EOJS
+
+    issues = run_engine(engine_conf).strip.split("\0")
+    expect(issues).to be_empty
+  end
 
   def engine_conf
     CC::Engine::Analyzers::EngineConfig.new({


### PR DESCRIPTION
Erring on the side of less is more when it comes to duplication, this avoids us flagging `require()`s as duplication.