### PR TITLE
Be more explicit in the name of clarity

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -150,7 +150,7 @@ module CC
           CC.logger.error(ex.message)
           CC.logger.debug { "Contents:\n#{processed_source.raw_source}" }
 
-          raise
+          raise ex
         end
       end
     end


### PR DESCRIPTION
Before merging my last PR, I pulled this out into a method. I noticed
after merging that, outside of the context of the rescue block, a bare
`raise` (without specifying the exception) is a little confusing. Raise
what? I double checked, and it actually works the same -- it raises the
error from $ERROR_INFO, which is the active error. But I still think
it's worth being more explicit.

https://gist.github.com/maxjacobson/e807c26444810aec1d2b0f4a91d03213