### PR TITLE
Only use `SexpLines` for old parsers

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -90,6 +90,11 @@ module CC
           sexp
         end
 
+        # Please see: codeclimate/app#6227
+        def use_sexp_lines?
+          true
+        end
+
         private
 
         attr_reader :engine_config

--- a/lib/cc/engine/analyzers/java/main.rb
+++ b/lib/cc/engine/analyzers/java/main.rb
@@ -20,6 +20,10 @@ module CC
           POINTS_PER_OVERAGE = 10_000
           REQUEST_PATH = "/java".freeze
 
+          def use_sexp_lines?
+            false
+          end
+
           private
 
           def process_file(file)

--- a/lib/cc/engine/analyzers/javascript/main.rb
+++ b/lib/cc/engine/analyzers/javascript/main.rb
@@ -20,6 +20,10 @@ module CC
           POINTS_PER_OVERAGE = 30_000
           REQUEST_PATH = "/javascript".freeze
 
+          def use_sexp_lines?
+            false
+          end
+
           private
 
           def process_file(file)

--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -23,6 +23,10 @@ module CC
             delete_comments!(sexp)
           end
 
+          def use_sexp_lines?
+            false
+          end
+
           private
 
           def process_file(file)

--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -85,14 +85,24 @@ module CC
         end
 
         def format_sexp(sexp)
-          lines = SexpLines.new(sexp)
-          {
-            "path": sexp.file.gsub(%r{^./}, ""),
-            "lines": {
-              "begin": lines.begin_line,
-              "end": lines.end_line,
-            },
-          }
+          if language_strategy.use_sexp_lines?
+            lines = SexpLines.new(sexp)
+            {
+              "path": sexp.file.gsub(%r{^./}, ""),
+              "lines": {
+                "begin": lines.begin_line,
+                "end": lines.end_line,
+              },
+            }
+          else
+            {
+              "path": sexp.file.gsub(%r{^./}, ""),
+              "lines": {
+                "begin": sexp.line,
+                "end": sexp.end_line,
+              },
+            }
+          end
         end
 
         def content_body

--- a/spec/cc/engine/analyzers/violations_spec.rb
+++ b/spec/cc/engine/analyzers/violations_spec.rb
@@ -5,7 +5,7 @@ module CC::Engine::Analyzers
     describe "#each" do
       let(:issue) { double(:issue, mass: 10, identical?: true) }
       let(:hashes) { sexps }
-      let(:language_strategy) { double(:language_strategy, calculate_points: 30, calculate_severity: CC::Engine::Analyzers::Base::MINOR) }
+      let(:language_strategy) { double(:language_strategy, calculate_points: 30, calculate_severity: CC::Engine::Analyzers::Base::MINOR, use_sexp_lines?: true) }
       let(:violations) { [] }
 
       before do


### PR DESCRIPTION
Addresses codeclimate/app#6227.