### PR TITLE
Bump cc-parser to b494

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codeclimate/codeclimate-parser:b491
+FROM codeclimate/codeclimate-parser:b494
 LABEL maintainer="Code Climate <hello@codeclimate.com>"
 
 # Reset from base image


### PR DESCRIPTION
Reverts "Fix missing positions in python", please see codeclimate/codeclimate-parser#111.