### PR TITLE
Logs file name and re-raises exceptions during processing

### DIFF
--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -72,13 +72,18 @@ module CC
           processed_files_count = Concurrent::AtomicFixnum.new
 
           pool.run do |file|
-            CC.logger.debug("Processing #{lang} file: #{file}")
+            begin
+              CC.logger.debug("Processing #{lang} file: #{file}")
 
-            sexp = language_strategy.run(file)
+              sexp = language_strategy.run(file)
 
-            process_sexp(sexp)
+              process_sexp(sexp)
 
-            processed_files_count.increment
+              processed_files_count.increment
+            rescue Exception => ex
+              CC.logger.warn("Error processing file: #{file}")
+              raise ex
+            end
           end
 
           pool.join


### PR DESCRIPTION
The engine can end up crashing with cryptic errors depending on the
source being analyzed, such as `stack level too deep
(SystemStackError)`.

This rescues exceptions encountered during file processing, logs the
file name, and then re-raises the exception. This will provide more
insight into the issue, and allows users to take action if appropriate
(for instance, excluding the file).

related: https://github.com/codeclimate/escalations/issues/179