### PR TITLE
Skip analysis is both types of duplication disabled

### DIFF
--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -6,7 +6,13 @@ module CC
       class EngineConfig
         DEFAULT_COUNT_THRESHOLD = 2
         IDENTICAL_CODE_CHECK = "identical-code".freeze
+        IDENTICAL_CODE_CHECK_LEGACY_NAME = "Identical code".freeze
         SIMILAR_CODE_CHECK = "similar-code".freeze
+        SIMILAR_CODE_CHECK_LEGACY_NAME = "Similar code".freeze
+        CHECK_MAPPINGS = {
+          IDENTICAL_CODE_CHECK_LEGACY_NAME => IDENTICAL_CODE_CHECK,
+          SIMILAR_CODE_CHECK_LEGACY_NAME => SIMILAR_CODE_CHECK,
+        }.freeze
 
         InvalidConfigError = Class.new(StandardError)
 
@@ -83,12 +89,18 @@ module CC
           Array(fetch_language(language).fetch("patterns", fallbacks))
         end
 
-        def check_enabled?(violation)
-          legacy_config = legacy_checks.fetch(violation.fingerprint_check_name, {
+        def check_enabled?(legacy_check_name, check_name)
+          legacy_config = legacy_checks.fetch(legacy_check_name, {
             "enabled" => true
           })
 
-          qm_checks.fetch(violation.check_name, legacy_config).fetch("enabled", true)
+          qm_checks.fetch(check_name, legacy_config).fetch("enabled", true)
+        end
+
+        def all_checks_disabled?
+          CHECK_MAPPINGS.none? do |legacy_check_name, check_name|
+            check_enabled?(legacy_check_name, check_name)
+          end
         end
 
         private

--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -163,7 +163,10 @@ module CC
         end
 
         def check_disabled?(violation)
-          !engine_config.check_enabled?(violation)
+          !engine_config.check_enabled?(
+            violation.fingerprint_check_name,
+            violation.check_name,
+          )
         end
       end
     end

--- a/lib/cc/engine/duplication.rb
+++ b/lib/cc/engine/duplication.rb
@@ -30,6 +30,8 @@ module CC
       end
 
       def run
+        return if engine_config.all_checks_disabled?
+
         Dir.chdir(directory) do
           languages_to_analyze.each do |language|
             engine = LANGUAGES[language].new(engine_config: engine_config)

--- a/spec/cc/engine/duplication_spec.rb
+++ b/spec/cc/engine/duplication_spec.rb
@@ -1,0 +1,28 @@
+require "spec_helper"
+require "cc/engine/duplication"
+
+RSpec.describe(CC::Engine::Duplication) do
+  describe "#run" do
+    it "skips analysis when all duplication checks are disabled" do
+      dir = "foo"
+      config = {
+        "config" => {
+          "checks" => {
+            "similar-code" => {
+              "enabled" => false,
+            },
+            "identical-code" => {
+              "enabled" => false,
+            },
+          },
+        },
+      }
+      expect(Dir).to_not receive(:chdir)
+      expect(CC::Engine::Analyzers::Reporter).to_not receive(:new)
+
+      CC::Engine::Duplication.new(
+        directory: dir, engine_config: config, io: double,
+      ).run
+    end
+  end
+end


### PR DESCRIPTION
Currently duplication analysis runs regardless of the configuration
settings, which are only checked at the time of issue reporting to
determine whether or not to emit it.

This means that if a configuration has all duplication disabled
(identical and similar code), analysis will still run on all files, and
then ultimately output nothing.

This change completely skips analysis if both types of duplication are
disabled.

related: https://github.com/codeclimate/escalations/issues/179#issuecomment-344429137