### PR TITLE
Pass `filename` to parser servers

### DIFF
--- a/lib/cc/engine/processed_source.rb
+++ b/lib/cc/engine/processed_source.rb
@@ -15,7 +15,7 @@ module CC
       end
 
       def ast
-        @ast ||= CC::Parser.parse(raw_source, request_path)
+        @ast ||= CC::Parser.parse(raw_source, request_path, filename: path)
       end
 
       private

--- a/spec/cc/engine/analyzers/javascript/main_spec.rb
+++ b/spec/cc/engine/analyzers/javascript/main_spec.rb
@@ -103,7 +103,7 @@ RSpec.describe CC::Engine::Analyzers::Javascript::Main, in_tmpdir: true do
       EOJS
 
       error = CC::Parser::Client::HTTPError.new(500, "Error processing file: ./foo.js")
-      allow(CC::Parser).to receive(:parse).with("", "/javascript").and_raise(error)
+      allow(CC::Parser).to receive(:parse).with("", "/javascript", filename: "./foo.js").and_raise(error)
 
       expect(CC.logger).to receive(:error).with("Error processing file: ./foo.js")
       expect(CC.logger).to receive(:error).with(error.message)


### PR DESCRIPTION
The ultimate aim here is to support parsing TypeScript and React (i.e.
`tsx`) files.

Ticket: codeclimate/app#6470.