### PR TITLE
Add support for TypeScript+React (tsx) files

### DIFF
--- a/lib/cc/engine/analyzers/typescript/main.rb
+++ b/lib/cc/engine/analyzers/typescript/main.rb
@@ -9,6 +9,7 @@ module CC
         class Main < CC::Engine::Analyzers::Base
           PATTERNS = [
             "**/*.ts",
+            "**/*.tsx",
           ]
           LANGUAGE = "typescript"
           DEFAULT_MASS_THRESHOLD = 45


### PR DESCRIPTION
Add `tsx` files to TypeScript analysis. Add a test for TypeScript+React
files. Fix a test broken by the parser change.

Ticket: codeclimate/app#6470.