### PR TITLE
Fix reporting on non-existent files

### DIFF
--- a/lib/cc/engine/analyzers/violation.rb
+++ b/lib/cc/engine/analyzers/violation.rb
@@ -88,7 +88,7 @@ module CC
           if language_strategy.use_sexp_lines?
             lines = SexpLines.new(sexp)
             {
-              "path": sexp.file.gsub(%r{^./}, ""),
+              "path": sexp.file.gsub(%r{^\./}, ""),
               "lines": {
                 "begin": lines.begin_line,
                 "end": lines.end_line,
@@ -96,7 +96,7 @@ module CC
             }
           else
             {
-              "path": sexp.file.gsub(%r{^./}, ""),
+              "path": sexp.file.gsub(%r{^\./}, ""),
               "lines": {
                 "begin": sexp.line,
                 "end": sexp.end_line,

--- a/spec/cc/engine/analyzers/violation_spec.rb
+++ b/spec/cc/engine/analyzers/violation_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+require "cc/engine/analyzers/violation"
+
+module CC::Engine::Analyzers
+  RSpec.describe Violation do
+    describe "#format" do
+      it "gives the correct path for paths with leading single char dir" do
+        sexp1 = Sexp.new([:foo, :a]).tap do |s|
+          s.line = 42
+          s.file = "_/a.rb"
+        end
+        sexp2 = Sexp.new([:foo, :a]).tap do |s|
+          s.line = 13
+          s.file = "T/b.rb"
+        end
+        engine_config = EngineConfig.new({})
+        language_strategy = Ruby::Main.new(
+          engine_config: engine_config,
+          parse_metrics: nil,
+        )
+        issue = described_class.new(
+          language_strategy: language_strategy,
+          identical: true,
+          current_sexp: sexp1,
+          other_sexps: [sexp2],
+        ).format
+
+        expect(issue[:location][:path]).to eq("_/a.rb")
+        expect(issue[:other_locations][0][:path]).to eq("T/b.rb")
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have at least as many bugs as we have regular expressions.

We're using this regex to strip path prefixes of `./`. That `.`, of
course, will match anything, meaning paths like `_/foo` end up as just
`foo`.

This bug has been in duplication for 2 years, which is almost
impressive.