### PR TITLE
Fix comment exclusion issue

### DIFF
--- a/lib/cc/engine/analyzers/go/main.rb
+++ b/lib/cc/engine/analyzers/go/main.rb
@@ -18,14 +18,14 @@ module CC
           ].freeze
           POINTS_PER_OVERAGE = 40_000
           REQUEST_PATH = "/go"
-          COMMENT_MATCHER = Sexp::Matcher.parse("(_ (comments ___) ___)")
-
-          def use_sexp_lines?
-            false
-          end
+          COMMENT_MATCHER = Sexp::Matcher.parse("(CommentGroup ___)")
 
           def transform_sexp(sexp)
             delete_comments!(sexp)
+          end
+
+          def use_sexp_lines?
+            false
           end
 
           private

--- a/spec/cc/engine/analyzers/go/main_spec.rb
+++ b/spec/cc/engine/analyzers/go/main_spec.rb
@@ -36,13 +36,13 @@ module CC::Engine::Analyzers
           "path" => "foo.go",
           "lines" => { "begin" => 6, "end" => 6 },
         })
-        expect(json["remediation_points"]).to eq(820_000)
+        expect(json["remediation_points"]).to eq(500_000)
         expect(json["other_locations"]).to eq([
           {"path" => "foo.go", "lines" => { "begin" => 7, "end" => 7} },
         ])
         expect(json["content"]["body"]).to match(/This issue has a mass of 16/)
         expect(json["fingerprint"]).to eq("484ee5799eb0e6c933751cfa85ba33c3")
-        expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MAJOR)
+        expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MINOR)
       end
 
       it "prints an issue for similar code" do
@@ -82,7 +82,7 @@ module CC::Engine::Analyzers
           "path" => "foo.go",
           "lines" => { "begin" => 5, "end" => 7 },
           })
-        expect(json["remediation_points"]).to eq(1_540_000)
+        expect(json["remediation_points"]).to eq(1_220_000)
         expect(json["other_locations"]).to eq([
           {"path" => "foo.go", "lines" => { "begin" => 9, "end" => 11} },
           {"path" => "foo.go", "lines" => { "begin" => 13, "end" => 15} },
@@ -129,13 +129,47 @@ module CC::Engine::Analyzers
 
       it "does not flag duplicate comments" do
         create_source_file("foo.go", <<-EOGO)
+          // This is a comment.
+          // This is a comment.
+          // This is a comment.
+          // This is also a comment.
+          // This is also a comment.
+
           package main
 
+          func main() {
+          }
+
+          /* This is a multiline comment */
+          /* This is a multiline comment */
+          /* This is a also multiline comment */
+          /* This is a also multiline comment */
+
+          // func add(x int, y int) int {
+          //   return x + y
+          // }
+
+          // func add(x int, y int) int {
+          //   return x + y
+          // }
+
+          // func add(x int, y int) int {
+          //   return x + y
+          // }
+
+          // func add(x int, y int) int {
+          //   return x + y
+          // }
+        EOGO
+
+        create_source_file("bar.go", <<-EOGO)
           // This is a comment.
           // This is a comment.
           // This is a comment.
           // This is also a comment.
           // This is also a comment.
+
+          package main
 
           func main() {
           }
@@ -178,7 +212,7 @@ module CC::Engine::Analyzers
             },
             'languages' => {
               'go' => {
-                'mass_threshold' => 3,
+                'mass_threshold' => 11,
               },
             },
           },


### PR DESCRIPTION
This fixes the comment exclusion issue referenced here: https://twitter.com/sdboyer/status/939159860159111169

I was originally trying to exclude comments as you would for a PHP s-exp and not Go, so I wasn't really excluding comments at all. 