### PR TITLE
Removes duplication definition of `skip?` method

### DIFF
--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -152,14 +152,6 @@ module CC
           (violation.occurrences + 1) < language_strategy.count_threshold
         end
 
-        def skip?(violation)
-          insufficient_occurrence?(violation) || check_disabled?(violation)
-        end
-
-        def insufficient_occurrence?(violation)
-          (violation.occurrences + 1) < language_strategy.count_threshold
-        end
-
         def check_disabled?(violation)
           !engine_config.check_enabled?(
             violation.fingerprint_check_name,


### PR DESCRIPTION
This fixes a bug where issues were being reported when the thresholds
were not being met, due to a second definition of `skip?` replacing the
correct one.

This also improves the specs to properly cover the behavior.

related: https://github.com/codeclimate/escalations/issues/206