### PR TITLE
Filter out "name" and "unresolved" nodes

### DIFF
--- a/lib/cc/engine/analyzers/go/main.rb
+++ b/lib/cc/engine/analyzers/go/main.rb
@@ -18,14 +18,14 @@ module CC
           ].freeze
           POINTS_PER_OVERAGE = 40_000
           REQUEST_PATH = "/go"
-          COMMENT_MATCHER = Sexp::Matcher.parse("(_ (comments ___) ___)")
-
-          def use_sexp_lines?
-            false
-          end
+          COMMENT_MATCHER = Sexp::Matcher.parse("(CommentGroup ___)")
 
           def transform_sexp(sexp)
             delete_comments!(sexp)
+          end
+
+          def use_sexp_lines?
+            false
           end
 
           private

--- a/lib/cc/engine/analyzers/go/main.rb
+++ b/lib/cc/engine/analyzers/go/main.rb
@@ -23,7 +23,6 @@ module CC
           def transform_sexp(sexp)
             delete_comments!(sexp)
             sexp.delete_if { |node| node[0] == :name }
-            sexp.delete_if { |node| node[0] == :unresolved }
           end
 
           def use_sexp_lines?

--- a/lib/cc/engine/analyzers/go/main.rb
+++ b/lib/cc/engine/analyzers/go/main.rb
@@ -18,10 +18,12 @@ module CC
           ].freeze
           POINTS_PER_OVERAGE = 40_000
           REQUEST_PATH = "/go"
-          COMMENT_MATCHER = Sexp::Matcher.parse("(CommentGroup ___)")
+          COMMENT_MATCHER = Sexp::Matcher.parse("(_ (comments ___) ___)")
 
           def transform_sexp(sexp)
             delete_comments!(sexp)
+            sexp.delete_if { |node| node[0] == :name }
+            sexp.delete_if { |node| node[0] == :unresolved }
           end
 
           def use_sexp_lines?

--- a/spec/cc/engine/analyzers/go/main_spec.rb
+++ b/spec/cc/engine/analyzers/go/main_spec.rb
@@ -36,13 +36,13 @@ module CC::Engine::Analyzers
           "path" => "foo.go",
           "lines" => { "begin" => 6, "end" => 6 },
         })
-        expect(json["remediation_points"]).to eq(820_000)
+        expect(json["remediation_points"]).to eq(500_000)
         expect(json["other_locations"]).to eq([
           {"path" => "foo.go", "lines" => { "begin" => 7, "end" => 7} },
         ])
         expect(json["content"]["body"]).to match(/This issue has a mass of 16/)
         expect(json["fingerprint"]).to eq("484ee5799eb0e6c933751cfa85ba33c3")
-        expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MAJOR)
+        expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MINOR)
       end
 
       it "prints an issue for similar code" do
@@ -82,7 +82,7 @@ module CC::Engine::Analyzers
           "path" => "foo.go",
           "lines" => { "begin" => 5, "end" => 7 },
           })
-        expect(json["remediation_points"]).to eq(1_540_000)
+        expect(json["remediation_points"]).to eq(1_220_000)
         expect(json["other_locations"]).to eq([
           {"path" => "foo.go", "lines" => { "begin" => 9, "end" => 11} },
           {"path" => "foo.go", "lines" => { "begin" => 13, "end" => 15} },
@@ -129,13 +129,47 @@ module CC::Engine::Analyzers
 
       it "does not flag duplicate comments" do
         create_source_file("foo.go", <<-EOGO)
+          // This is a comment.
+          // This is a comment.
+          // This is a comment.
+          // This is also a comment.
+          // This is also a comment.
+
           package main
 
+          func main() {
+          }
+
+          /* This is a multiline comment */
+          /* This is a multiline comment */
+          /* This is a also multiline comment */
+          /* This is a also multiline comment */
+
+          // func add(x int, y int) int {
+          //   return x + y
+          // }
+
+          // func add(x int, y int) int {
+          //   return x + y
+          // }
+
+          // func add(x int, y int) int {
+          //   return x + y
+          // }
+
+          // func add(x int, y int) int {
+          //   return x + y
+          // }
+        EOGO
+
+        create_source_file("bar.go", <<-EOGO)
           // This is a comment.
           // This is a comment.
           // This is a comment.
           // This is also a comment.
           // This is also a comment.
+
+          package main
 
           func main() {
           }
@@ -178,7 +212,7 @@ module CC::Engine::Analyzers
             },
             'languages' => {
               'go' => {
-                'mass_threshold' => 3,
+                'mass_threshold' => 11,
               },
             },
           },

--- a/spec/fixtures/issue_6609_1.go
+++ b/spec/fixtures/issue_6609_1.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"encoding/json"
+	fmtlog "log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/Sirupsen/logrus"
+	"github.com/cenk/backoff"
+	"github.com/containous/flaeg"
+	"github.com/containous/staert"
+	"github.com/containous/traefik/acme"
+	"github.com/containous/traefik/collector"
+	"github.com/containous/traefik/configuration"
+	"github.com/containous/traefik/job"
+	"github.com/containous/traefik/log"
+	"github.com/containous/traefik/provider/ecs"
+	"github.com/containous/traefik/provider/kubernetes"
+	"github.com/containous/traefik/safe"
+	"github.com/containous/traefik/server"
+	"github.com/containous/traefik/server/uuid"
+	traefikTls "github.com/containous/traefik/tls"
+	"github.com/containous/traefik/types"
+	"github.com/containous/traefik/version"
+	"github.com/coreos/go-systemd/daemon"
+)
+
+func main() {
+	//traefik config inits
+	traefikConfiguration := NewTraefikConfiguration()
+	traefikPointersConfiguration := NewTraefikDefaultPointersConfiguration()
+	//traefik Command init
+	traefikCmd := &flaeg.Command{
+		Name: "traefik",
+		Description: `traefik is a modern HTTP reverse proxy and load balancer made to deploy microservices with ease.
+Complete documentation is available at https://traefik.io`,
+		Config:                traefikConfiguration,
+		DefaultPointersConfig: traefikPointersConfiguration,
+		Run: func() error {
+			run(&traefikConfiguration.GlobalConfiguration, traefikConfiguration.ConfigFile)
+			return nil
+		},
+	}
+
+	//storeconfig Command init
+	storeConfigCmd := newStoreConfigCmd(traefikConfiguration, traefikPointersConfiguration)
+
+	//init flaeg source
+	f := flaeg.New(traefikCmd, os.Args[1:])
+	//add custom parsers
+	f.AddParser(reflect.TypeOf(configuration.EntryPoints{}), &configuration.EntryPoints{})
+	f.AddParser(reflect.TypeOf(configuration.DefaultEntryPoints{}), &configuration.DefaultEntryPoints{})
+	f.AddParser(reflect.TypeOf(traefikTls.RootCAs{}), &traefikTls.RootCAs{})
+	f.AddParser(reflect.TypeOf(types.Constraints{}), &types.Constraints{})
+	f.AddParser(reflect.TypeOf(kubernetes.Namespaces{}), &kubernetes.Namespaces{})
+	f.AddParser(reflect.TypeOf(ecs.Clusters{}), &ecs.Clusters{})
+	f.AddParser(reflect.TypeOf([]acme.Domain{}), &acme.Domains{})
+	f.AddParser(reflect.TypeOf(types.Buckets{}), &types.Buckets{})
+
+	//add commands
+	f.AddCommand(newVersionCmd())
+	f.AddCommand(newBugCmd(traefikConfiguration, traefikPointersConfiguration))
+	f.AddCommand(storeConfigCmd)
+	f.AddCommand(newHealthCheckCmd(traefikConfiguration, traefikPointersConfiguration))
+
+	usedCmd, err := f.GetCommand()
+	if err != nil {
+		fmtlog.Println(err)
+		os.Exit(-1)
+	}
+
+	if _, err := f.Parse(usedCmd); err != nil {
+		fmtlog.Printf("Error parsing command: %s\n", err)
+		os.Exit(-1)
+	}
+
+	//staert init
+	s := staert.NewStaert(traefikCmd)
+	//init toml source
+	toml := staert.NewTomlSource("traefik", []string{traefikConfiguration.ConfigFile, "/etc/traefik/", "$HOME/.traefik/", "."})
+
+	//add sources to staert
+	s.AddSource(toml)
+	s.AddSource(f)
+	if _, err := s.LoadConfig(); err != nil {
+		fmtlog.Printf("Error reading TOML config file %s : %s\n", toml.ConfigFileUsed(), err)
+		os.Exit(-1)
+	}
+
+	traefikConfiguration.ConfigFile = toml.ConfigFileUsed()
+
+	kv, err := createKvSource(traefikConfiguration)
+	if err != nil {
+		fmtlog.Printf("Error creating kv store: %s\n", err)
+		os.Exit(-1)
+	}
+	storeConfigCmd.Run = runStoreConfig(kv, traefikConfiguration)
+
+	// IF a KV Store is enable and no sub-command called in args
+	if kv != nil && usedCmd == traefikCmd {
+		if traefikConfiguration.Cluster == nil {
+			traefikConfiguration.Cluster = &types.Cluster{Node: uuid.Get()}
+		}
+		if traefikConfiguration.Cluster.Store == nil {
+			traefikConfiguration.Cluster.Store = &types.Store{Prefix: kv.Prefix, Store: kv.Store}
+		}
+		s.AddSource(kv)
+		operation := func() error {
+			_, err := s.LoadConfig()
+			return err
+		}
+		notify := func(err error, time time.Duration) {
+			log.Errorf("Load config error: %+v, retrying in %s", err, time)
+		}
+		err := backoff.RetryNotify(safe.OperationWithRecover(operation), job.NewBackOff(backoff.NewExponentialBackOff()), notify)
+		if err != nil {
+			fmtlog.Printf("Error loading configuration: %s\n", err)
+			os.Exit(-1)
+		}
+	}
+
+	if err := s.Run(); err != nil {
+		fmtlog.Printf("Error running traefik: %s\n", err)
+		os.Exit(-1)
+	}
+
+	os.Exit(0)
+}
+
+func run(globalConfiguration *configuration.GlobalConfiguration, configFile string) {
+	configureLogging(globalConfiguration)
+
+	if len(configFile) > 0 {
+		log.Infof("Using TOML configuration file %s", configFile)
+	}
+
+	http.DefaultTransport.(*http.Transport).Proxy = http.ProxyFromEnvironment
+
+	globalConfiguration.SetEffectiveConfiguration(configFile)
+
+	jsonConf, _ := json.Marshal(globalConfiguration)
+	log.Infof("Traefik version %s built on %s", version.Version, version.BuildDate)
+
+	if globalConfiguration.CheckNewVersion {
+		checkNewVersion()
+	}
+
+	stats(globalConfiguration)
+
+	log.Debugf("Global configuration loaded %s", string(jsonConf))
+	svr := server.NewServer(*globalConfiguration)
+	svr.Start()
+	defer svr.Close()
+
+	sent, err := daemon.SdNotify(false, "READY=1")
+	if !sent && err != nil {
+		log.Error("Fail to notify", err)
+	}
+
+	t, err := daemon.SdWatchdogEnabled(false)
+	if err != nil {
+		log.Error("Problem with watchdog", err)
+	} else if t != 0 {
+		// Send a ping each half time given
+		t = t / 2
+		log.Info("Watchdog activated with timer each ", t)
+		safe.Go(func() {
+			tick := time.Tick(t)
+			for range tick {
+				_, errHealthCheck := healthCheck(*globalConfiguration)
+				if globalConfiguration.Ping == nil || errHealthCheck == nil {
+					if ok, _ := daemon.SdNotify(false, "WATCHDOG=1"); !ok {
+						log.Error("Fail to tick watchdog")
+					}
+				} else {
+					log.Error(errHealthCheck)
+				}
+			}
+		})
+	}
+
+	svr.Wait()
+	log.Info("Shutting down")
+	logrus.Exit(0)
+}
+
+func configureLogging(globalConfiguration *configuration.GlobalConfiguration) {
+	// configure default log flags
+	fmtlog.SetFlags(fmtlog.Lshortfile | fmtlog.LstdFlags)
+
+	if globalConfiguration.Debug {
+		globalConfiguration.LogLevel = "DEBUG"
+	}
+
+	// configure log level
+	level, err := logrus.ParseLevel(strings.ToLower(globalConfiguration.LogLevel))
+	if err != nil {
+		log.Error("Error getting level", err)
+	}
+	log.SetLevel(level)
+
+	// configure log output file
+	logFile := globalConfiguration.TraefikLogsFile
+	if len(logFile) > 0 {
+		log.Warn("top-level traefikLogsFile has been deprecated -- please use traefiklog.filepath")
+	}
+	if globalConfiguration.TraefikLog != nil && len(globalConfiguration.TraefikLog.FilePath) > 0 {
+		logFile = globalConfiguration.TraefikLog.FilePath
+	}
+
+	// configure log format
+	var formatter logrus.Formatter
+	if globalConfiguration.TraefikLog != nil && globalConfiguration.TraefikLog.Format == "json" {
+		formatter = &logrus.JSONFormatter{}
+	} else {
+		disableColors := false
+		if len(logFile) > 0 {
+			disableColors = true
+		}
+		formatter = &logrus.TextFormatter{DisableColors: disableColors, FullTimestamp: true, DisableSorting: true}
+	}
+	log.SetFormatter(formatter)
+
+	if len(logFile) > 0 {
+		dir := filepath.Dir(logFile)
+
+		err := os.MkdirAll(dir, 0755)
+		if err != nil {
+			log.Errorf("Failed to create log path %s: %s", dir, err)
+		}
+
+		err = log.OpenFile(logFile)
+		logrus.RegisterExitHandler(func() {
+			if err := log.CloseFile(); err != nil {
+				log.Error("Error closing log", err)
+			}
+		})
+		if err != nil {
+			log.Error("Error opening file", err)
+		}
+	}
+}
+
+func checkNewVersion() {
+	ticker := time.Tick(24 * time.Hour)
+	safe.Go(func() {
+		for time.Sleep(10 * time.Minute); ; <-ticker {
+			version.CheckNewVersion()
+		}
+	})
+}
+
+func stats(globalConfiguration *configuration.GlobalConfiguration) {
+	if globalConfiguration.SendAnonymousUsage {
+		log.Info(`
+Stats collection is enabled.
+Many thanks for contributing to Traefik's improvement by allowing us to receive anonymous information from your configuration.
+Help us improve Traefik by leaving this feature on :)
+More details on: https://docs.traefik.io/basic/#collected-data
+`)
+		collect(globalConfiguration)
+	} else {
+		log.Info(`
+Stats collection is disabled.
+Help us improve Traefik by turning this feature on :)
+More details on: https://docs.traefik.io/basic/#collected-data
+`)
+	}
+}
+
+func collect(globalConfiguration *configuration.GlobalConfiguration) {
+	ticker := time.Tick(24 * time.Hour)
+	safe.Go(func() {
+		for time.Sleep(10 * time.Minute); ; <-ticker {
+			if err := collector.Collect(globalConfiguration); err != nil {
+				log.Debug(err)
+			}
+		}
+	})
+}

--- a/spec/fixtures/issue_6609_2.go
+++ b/spec/fixtures/issue_6609_2.go
@@ -1,0 +1,250 @@
+package rancher
+
+import (
+	"context"
+	"os"
+	"time"
+
+	"github.com/cenk/backoff"
+	"github.com/containous/traefik/job"
+	"github.com/containous/traefik/log"
+	"github.com/containous/traefik/safe"
+	"github.com/containous/traefik/types"
+	"github.com/mitchellh/mapstructure"
+	rancher "github.com/rancher/go-rancher/v2"
+)
+
+const (
+	labelRancherStackServiceName = "io.rancher.stack_service.name"
+	hostNetwork                  = "host"
+)
+
+var withoutPagination *rancher.ListOpts
+
+// APIConfiguration contains configuration properties specific to the Rancher
+// API provider.
+type APIConfiguration struct {
+	Endpoint  string `description:"Rancher server API HTTP(S) endpoint"`
+	AccessKey string `description:"Rancher server API access key"`
+	SecretKey string `description:"Rancher server API secret key"`
+}
+
+func init() {
+	withoutPagination = &rancher.ListOpts{
+		Filters: map[string]interface{}{"limit": 0},
+	}
+}
+
+func (p *Provider) createClient() (*rancher.RancherClient, error) {
+	rancherURL := getenv("CATTLE_URL", p.API.Endpoint)
+	accessKey := getenv("CATTLE_ACCESS_KEY", p.API.AccessKey)
+	secretKey := getenv("CATTLE_SECRET_KEY", p.API.SecretKey)
+
+	return rancher.NewRancherClient(&rancher.ClientOpts{
+		Url:       rancherURL,
+		AccessKey: accessKey,
+		SecretKey: secretKey,
+	})
+}
+
+func getenv(key, fallback string) string {
+	value := os.Getenv(key)
+	if len(value) == 0 {
+		return fallback
+	}
+	return value
+}
+
+func (p *Provider) apiProvide(configurationChan chan<- types.ConfigMessage, pool *safe.Pool, constraints types.Constraints) error {
+	p.Constraints = append(p.Constraints, constraints...)
+
+	if p.API == nil {
+		p.API = &APIConfiguration{}
+	}
+
+	safe.Go(func() {
+		operation := func() error {
+			rancherClient, err := p.createClient()
+
+			if err != nil {
+				log.Errorf("Failed to create a client for rancher, error: %s", err)
+				return err
+			}
+
+			ctx := context.Background()
+			var stacks = listRancherStacks(rancherClient)
+			var services = listRancherServices(rancherClient)
+			var container = listRancherContainer(rancherClient)
+
+			var rancherData = parseAPISourcedRancherData(stacks, services, container)
+
+			configuration := p.buildConfiguration(rancherData)
+			configurationChan <- types.ConfigMessage{
+				ProviderName:  "rancher",
+				Configuration: configuration,
+			}
+
+			if p.Watch {
+				_, cancel := context.WithCancel(ctx)
+				ticker := time.NewTicker(time.Second * time.Duration(p.RefreshSeconds))
+				pool.Go(func(stop chan bool) {
+					for {
+						select {
+						case <-ticker.C:
+
+							log.Debugf("Refreshing new Data from Provider API")
+							var stacks = listRancherStacks(rancherClient)
+							var services = listRancherServices(rancherClient)
+							var container = listRancherContainer(rancherClient)
+
+							rancherData := parseAPISourcedRancherData(stacks, services, container)
+
+							configuration := p.buildConfiguration(rancherData)
+							if configuration != nil {
+								configurationChan <- types.ConfigMessage{
+									ProviderName:  "rancher",
+									Configuration: configuration,
+								}
+							}
+						case <-stop:
+							ticker.Stop()
+							cancel()
+							return
+						}
+					}
+				})
+			}
+
+			return nil
+		}
+		notify := func(err error, time time.Duration) {
+			log.Errorf("Provider connection error %+v, retrying in %s", err, time)
+		}
+		err := backoff.RetryNotify(operation, job.NewBackOff(backoff.NewExponentialBackOff()), notify)
+		if err != nil {
+			log.Errorf("Cannot connect to Provider Endpoint %+v", err)
+		}
+	})
+
+	return nil
+}
+
+func listRancherStacks(client *rancher.RancherClient) []*rancher.Stack {
+
+	var stackList []*rancher.Stack
+
+	stacks, err := client.Stack.List(withoutPagination)
+
+	if err != nil {
+		log.Errorf("Cannot get Provider Stacks %+v", err)
+	}
+
+	for k := range stacks.Data {
+		stackList = append(stackList, &stacks.Data[k])
+	}
+
+	return stackList
+}
+
+func listRancherServices(client *rancher.RancherClient) []*rancher.Service {
+
+	var servicesList []*rancher.Service
+
+	services, err := client.Service.List(withoutPagination)
+
+	if err != nil {
+		log.Errorf("Cannot get Provider Services %+v", err)
+	}
+
+	for k := range services.Data {
+		servicesList = append(servicesList, &services.Data[k])
+	}
+
+	return servicesList
+}
+
+func listRancherContainer(client *rancher.RancherClient) []*rancher.Container {
+
+	var containerList []*rancher.Container
+
+	container, err := client.Container.List(withoutPagination)
+
+	if err != nil {
+		log.Errorf("Cannot get Provider Services %+v", err)
+	}
+
+	valid := true
+
+	for valid {
+		for k := range container.Data {
+			containerList = append(containerList, &container.Data[k])
+		}
+
+		container, err = container.Next()
+
+		if err != nil {
+			break
+		}
+
+		if container == nil || len(container.Data) == 0 {
+			valid = false
+		}
+	}
+
+	return containerList
+}
+
+func parseAPISourcedRancherData(stacks []*rancher.Stack, services []*rancher.Service, containers []*rancher.Container) []rancherData {
+	var rancherDataList []rancherData
+
+	for _, stack := range stacks {
+
+		for _, service := range services {
+
+			if service.StackId != stack.Id {
+				continue
+			}
+
+			rData := rancherData{
+				Name:       service.Name + "/" + stack.Name,
+				Health:     service.HealthState,
+				State:      service.State,
+				Labels:     make(map[string]string),
+				Containers: []string{},
+			}
+
+			if service.LaunchConfig == nil || service.LaunchConfig.Labels == nil {
+				log.Warnf("Rancher Service Labels are missing. Stack: %s, service: %s", stack.Name, service.Name)
+			} else {
+				for key, value := range service.LaunchConfig.Labels {
+					rData.Labels[key] = value.(string)
+				}
+			}
+
+			for _, container := range containers {
+				if container.Labels[labelRancherStackServiceName] == stack.Name+"/"+service.Name &&
+					containerFilter(container.Name, container.HealthState, container.State) {
+
+					if container.NetworkMode == hostNetwork {
+						var endpoints []*rancher.PublicEndpoint
+						err := mapstructure.Decode(service.PublicEndpoints, &endpoints)
+
+						if err != nil {
+							log.Errorf("Failed to decode PublicEndpoint: %v", err)
+							continue
+						}
+
+						if len(endpoints) > 0 {
+							rData.Containers = append(rData.Containers, endpoints[0].IpAddress)
+						}
+					} else {
+						rData.Containers = append(rData.Containers, container.PrimaryIpAddress)
+					}
+				}
+			}
+			rancherDataList = append(rancherDataList, rData)
+		}
+	}
+
+	return rancherDataList
+}


### PR DESCRIPTION
This is in response to issue https://github.com/codeclimate/app/issues/6609. 

@toddmazierski and I paired on this Go duplication bug yesterday afternoon and came up with this fix. It's patchwork and we agree that the real fix should be at the parser level, since it's essentially returning a lot of information we don't need (see: https://github.com/codeclimate/app/issues/6609). 

My inclination would be to merge this in now since the bug is currently live in production, but ultimately fix the parser.

Thoughts @wfleming @katwchen ?