### PR TITLE
Adjust DEFAULT_MASS_THRESHOLD and POINTS_PER_OVERAGE

### DIFF
--- a/lib/cc/engine/analyzers/go/main.rb
+++ b/lib/cc/engine/analyzers/go/main.rb
@@ -12,11 +12,11 @@ module CC
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "go"
           PATTERNS = ["**/*.go"].freeze
-          DEFAULT_MASS_THRESHOLD = 30
+          DEFAULT_MASS_THRESHOLD = 100
           DEFAULT_FILTERS = [
             "(ImportSpec ___)",
           ].freeze
-          POINTS_PER_OVERAGE = 40_000
+          POINTS_PER_OVERAGE = 10_000
           REQUEST_PATH = "/go"
           COMMENT_MATCHER = Sexp::Matcher.parse("(_ (comments ___) ___)")
 

--- a/spec/cc/engine/analyzers/go/main_spec.rb
+++ b/spec/cc/engine/analyzers/go/main_spec.rb
@@ -36,7 +36,7 @@ module CC::Engine::Analyzers
           "path" => "foo.go",
           "lines" => { "begin" => 6, "end" => 6 },
         })
-        expect(json["remediation_points"]).to eq(540_000)
+        expect(json["remediation_points"]).to eq(360_000)
         expect(json["other_locations"]).to eq([
           {"path" => "foo.go", "lines" => { "begin" => 7, "end" => 7} },
         ])
@@ -82,7 +82,7 @@ module CC::Engine::Analyzers
           "path" => "foo.go",
           "lines" => { "begin" => 5, "end" => 7 },
           })
-        expect(json["remediation_points"]).to eq(1_260_000)
+        expect(json["remediation_points"]).to eq(540_000)
         expect(json["other_locations"]).to eq([
           {"path" => "foo.go", "lines" => { "begin" => 9, "end" => 11} },
           {"path" => "foo.go", "lines" => { "begin" => 13, "end" => 15} },


### PR DESCRIPTION
This fix sets the ```DEFAULT_MASS_THRESHOLD``` to 100 and the ```POINTS_PER_OVERAGE``` to 10,000, which is more reasonable based on the Go AST.

The previous ```DEFAULT_MASS_THRESHOLD``` was simply too low and allowing tiny issues to be flagged as duplication. Similarly, the previous ```POINTS_PER_OVERAGE``` was too high and was representing a time-to-fix that was abnormally long. 