### PR TITLE
Add `make bundle` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,3 +10,9 @@ test: image
 
 citest:
 	docker run --rm $(IMAGE_NAME) bundle exec rake
+
+bundle:
+	docker run --rm \
+	  --entrypoint /bin/sh \
+	  --volume $(PWD):/usr/src/app \
+	  $(IMAGE_NAME) -c "bundle $(BUNDLE_ARGS)"


### PR DESCRIPTION
Add a `make bundle` command. Like our other projects, it uses a `BUNDLE_ARGS` environment variable so sub-commands like `update`, `list`, etc. can be used.