### PR TITLE
Fix count_threshold example configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ You can also change the default `count_threshold` for all languages:
 plugins:
   duplication:
     enabled: true
-    count_threshold: 3
+    config:
+      count_threshold: 3
 ```
 
 ### Custom file name patterns


### PR DESCRIPTION
The custom `count_threshold` example for all languages in the README doesn't work. `count_threshold` should be set inside the `config` key to work properly.