### PR TITLE
Update for filtering

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -58,6 +58,10 @@ module CC
           engine_config.filters_for(language) | default_filters
         end
 
+        def post_filters
+          engine_config.post_filters_for(language) | default_post_filters
+        end
+
         def language
           self.class::LANGUAGE
         end
@@ -105,6 +109,10 @@ module CC
         end
 
         def default_filters
+          []
+        end
+
+        def default_post_filters
           []
         end
 

--- a/lib/cc/engine/analyzers/engine_config.rb
+++ b/lib/cc/engine/analyzers/engine_config.rb
@@ -42,6 +42,12 @@ module CC
           end
         end
 
+        def post_filters_for(language)
+          fetch_language(language).fetch("post_filters", []).map do |filter|
+            Sexp::Matcher.parse filter
+          end
+        end
+
         def minimum_mass_threshold_for(language)
           [
             mass_threshold_for(language, IDENTICAL_CODE_CHECK),

--- a/lib/cc/engine/analyzers/reporter.rb
+++ b/lib/cc/engine/analyzers/reporter.rb
@@ -133,6 +133,7 @@ module CC
           changes = {
             mass: language_strategy.mass_threshold,
             filters: language_strategy.filters,
+            post_filters: language_strategy.post_filters,
           }
 
           CCFlay.default_options.merge changes

--- a/lib/ccflay.rb
+++ b/lib/ccflay.rb
@@ -18,6 +18,25 @@ class CCFlay < Flay
     self.identical = Concurrent::Hash.new
     self.masses = Concurrent::Hash.new
   end
+
+  def post_filter *patterns
+    return if patterns.empty?
+
+    self.hashes.delete_if { |_, sexps|
+      sexps.any? { |sexp|
+        patterns.any? { |pattern|
+          # pattern =~ sexp
+          pattern.satisfy? sexp
+        }
+      }
+    }
+  end
+
+  def prune
+    post_filter(*option[:post_filters])
+
+    super
+  end
 end
 
 class Sexp


### PR DESCRIPTION
This brings back the post-filtering from flay 2.11 into CCFlay and hooks it up via separate config. It also adds a rewrite layer for javascript and improves javascript's filters to reduce idiomatic false positives.