### PR TITLE
Increase Kotlin duplication mass threshold

### DIFF
--- a/lib/cc/engine/analyzers/kotlin/main.rb
+++ b/lib/cc/engine/analyzers/kotlin/main.rb
@@ -12,7 +12,7 @@ module CC
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "kotlin".freeze
           PATTERNS = ["**/*.kt"].freeze
-          DEFAULT_MASS_THRESHOLD = 40
+          DEFAULT_MASS_THRESHOLD = 60
           DEFAULT_FILTERS = [
             "(IMPORT_LIST ___)".freeze,
             "(PACKAGE_DIRECTIVE ___)".freeze,


### PR DESCRIPTION
- After looking at some of the duplication issues this was surfacing locally and running some metrics, I think it would be good to bump this from `40` to `60`