### PR TITLE
Ignore PHP namespace statements

### DIFF
--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -13,6 +13,7 @@ module CC
           ].freeze
           DEFAULT_MASS_THRESHOLD = 75
           DEFAULT_FILTERS = [
+            "(Stmt_Namespace ___)",
             "(Stmt_Use ___)",
             "(comments ___)",
           ].freeze

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -169,6 +169,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
       create_source_file("foo.php", <<~EOPHP)
       <?php
       namespace KeepClear\\Http\\Controllers\\API\\V1;
+
       use Illuminate\\Http\\Request;
       use KeepClear\\Http\\Controllers\\Controller;
       use KeepClear\\Models\\Comment;
@@ -177,12 +178,14 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
       use KeepClear\\Traits\\Controllers\\ApiFilter;
       use KeepClear\\Traits\\Controllers\\ApiParseBody;
       use KeepClear\\Traits\\Controllers\\ApiException;
+      
       a / b;
       EOPHP
 
       create_source_file("bar.php", <<~EOPHP)
       <?php
       namespace KeepClear\\Http\\Controllers\\API\\V1;
+
       use Illuminate\\Http\\Request;
       use KeepClear\\Http\\Controllers\\Controller;
       use KeepClear\\Models\\Comment;
@@ -191,6 +194,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
       use KeepClear\\Traits\\Controllers\\ApiFilter;
       use KeepClear\\Traits\\Controllers\\ApiParseBody;
       use KeepClear\\Traits\\Controllers\\ApiException;
+
       a + b;
       EOPHP
 


### PR DESCRIPTION
We're seeing hundreds of code duplication warnings for namespace statements.

<img width="833" alt="screen shot 2018-07-20 at 9 08 17 am" src="https://user-images.githubusercontent.com/665029/43013059-84ce6f02-8bfc-11e8-9c83-0c25eee6769d.png">

#245 didn't include the actual `namespace` statements and this PR covers the case when there is a space between the `namespace` and `use` blocks.