### PR TITLE
Remove docker login step from Circle yml

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,7 +12,6 @@ dependencies:
       --env GCR_JSON_KEY
       --volume /var/run/docker.sock:/var/run/docker.sock
       codeclimate/patrick pull || true
-    - docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD" --email "$DOCKER_EMAIL"
     - make image
 
 test:


### PR DESCRIPTION
This removes the docker login step from our Circle yml. The idea is
that this is pulling the parser image, which was private when we added
this step. However, the parser image is now public.

This is also blocking OSS contributions from users who have forked
duplication, since Circle fails at this step on forks.

Co-authored-by: Max Jacobson <max@hardscrabble.net>