### PR TITLE
Add .py3 extension to python file patterns

### DIFF
--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -12,7 +12,7 @@ module CC
       module Python
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "python"
-          PATTERNS = ["**/*.py"].freeze
+          PATTERNS = ["**/*.py", "**/*.py3"].freeze
           DEFAULT_MASS_THRESHOLD = 32
           DEFAULT_PYTHON_VERSION = 2
           POINTS_PER_OVERAGE = 50_000


### PR DESCRIPTION
Our Python parser already supports both Python 2 and Python 3 source code. While most Python 3 files share the same `.py` file extension used for Python 2 files, some projects use the `.py3` file extension.