### PR TITLE
Add .py3 pattern only when Python 3 language is specified

### DIFF
--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -129,7 +129,7 @@ module CC
             engine_config: engine_config,
             patterns: engine_config.patterns_for(
               language,
-              self.class::PATTERNS,
+              patterns,
             ),
           )
         end
@@ -168,6 +168,10 @@ module CC
             raise ex
           end
           nil
+        end
+
+        def patterns
+          self.class::PATTERNS
         end
       end
     end

--- a/lib/cc/engine/analyzers/python/main.rb
+++ b/lib/cc/engine/analyzers/python/main.rb
@@ -12,7 +12,6 @@ module CC
       module Python
         class Main < CC::Engine::Analyzers::Base
           LANGUAGE = "python"
-          PATTERNS = ["**/*.py", "**/*.py3"].freeze
           DEFAULT_MASS_THRESHOLD = 32
           DEFAULT_PYTHON_VERSION = 2
           POINTS_PER_OVERAGE = 50_000
@@ -33,6 +32,17 @@ module CC
 
           def python_version
             engine_config.fetch_language(LANGUAGE).fetch("python_version", DEFAULT_PYTHON_VERSION)
+          end
+
+          def patterns
+            case python_version
+            when 2, "2"
+              ["**/*.py"]
+            when 3, "3"
+              ["**/*.py", "**/*.py3"]
+            else
+              raise ArgumentError, "Supported python versions are 2 and 3. You configured: #{python_version.inspect}"
+            end
           end
         end
       end


### PR DESCRIPTION
Files containing Python 3 code may have either a `.py` or the less common `.py3` file extension. Python 2 code should only have the `.py` file extension, unless it's an executable file targeting a Python interpreter with a shebang.

This allows the file patterns to be dynamic depending on the configuration value.

This is a follow-up to #333.