### PR TITLE
README: update installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ simple. We have a [docs page][what-is-duplication] explaining the algorithm.
 ## Installation
 
 1. Install the [Code Climate CLI][cli], if you haven't already.
-3. You're ready to analyze! `cd` into your project's folder and run `codeclimate
+1. You're ready to analyze! `cd` into your project's folder and run `codeclimate
    analyze`. Duplication analysis is enabled by default, so you don't need to do
    anything else.
 

--- a/README.md
+++ b/README.md
@@ -14,10 +14,9 @@ simple. We have a [docs page][what-is-duplication] explaining the algorithm.
 ## Installation
 
 1. Install the [Code Climate CLI][cli], if you haven't already.
-2. Run `codeclimate engines:enable duplication`. This command installs the
-   engine and enables it in your `.codeclimate.yml` file.
 3. You're ready to analyze! `cd` into your project's folder and run `codeclimate
-   analyze`.
+   analyze`. Duplication analysis is enabled by default, so you don't need to do
+   anything else.
 
 ## Configuring
 


### PR DESCRIPTION
There is no `engines:enable` command anymore, and duplication is on by default.