### PR TITLE
Python3: don't crash on bytes literal

### DIFF
--- a/lib/cc/engine/analyzers/python/parser.py
+++ b/lib/cc/engine/analyzers/python/parser.py
@@ -29,6 +29,8 @@ def cast_infinity(value):
 def cast_value(value):
     if value is None or isinstance(value, (bool, string_type())):
         return value
+    elif PY3 and isinstance(value, bytes):
+        return value.decode()
     elif isinstance(value, num_types()):
         if abs(value) == 1e3000:
             return cast_infinity(value)

--- a/spec/cc/engine/analyzers/python/main_spec.rb
+++ b/spec/cc/engine/analyzers/python/main_spec.rb
@@ -74,6 +74,9 @@ def b(thing: str):
 
 def c(thing: str):
   print("Hello", str)
+
+def b(thing: str):
+  bytes_literal = b'asdf'
       EOJS
 
       conf = CC::Engine::Analyzers::EngineConfig.new({


### PR DESCRIPTION
What happens is that we try to cast this business from the AST to JSON,
which does not work. In python 2, it's just treated like a regular
string. But in python 3, we recognize that it is a bytes literal.

This implemention casts the bytes literal to a string, which is a type
that is serialiable to JSON:

```
>>> (b'hello').decode()
'hello'
```

This will default to utf8, and generally works, although it's possible
sometimes it will not work if the source file is encoded differently.

https://docs.python.org/3/library/stdtypes.html#bytes.decode

An alternative is to cast it to an array of integers, which would also
work for structural-comparison purposes:

```
>>> list(b'hello')
[104, 101, 108, 108, 111]
```