### PR TITLE
Bump parser to b859

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codeclimate/codeclimate-parser:b850
+FROM codeclimate/codeclimate-parser:b859
 LABEL maintainer="Code Climate <hello@codeclimate.com>"
 
 # Reset from base image

--- a/lib/cc/engine/analyzers/php/main.rb
+++ b/lib/cc/engine/analyzers/php/main.rb
@@ -11,12 +11,12 @@ module CC
           PATTERNS = [
             "**/*.php",
           ].freeze
-          DEFAULT_MASS_THRESHOLD = 75
+          DEFAULT_MASS_THRESHOLD = 90
           DEFAULT_FILTERS = [
             "(Stmt_Use ___)",
             "(comments ___)",
           ].freeze
-          POINTS_PER_OVERAGE = 35_000
+          POINTS_PER_OVERAGE = 29_000
           REQUEST_PATH = "/php"
 
           def use_sexp_lines?

--- a/spec/cc/engine/analyzers/php/main_spec.rb
+++ b/spec/cc/engine/analyzers/php/main_spec.rb
@@ -40,12 +40,12 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
         "path" => "foo.php",
         "lines" => { "begin" => 2, "end" => 8 },
       })
-      expect(json["remediation_points"]).to eq(965_000)
+      expect(json["remediation_points"]).to eq(967000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.php", "lines" => { "begin" => 10, "end" => 16} },
       ])
-      expect(json["content"]["body"]).to match(/This issue has a mass of 24/)
-      expect(json["fingerprint"]).to eq("367e371730140daeda61ab577c617236")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 28/)
+      expect(json["fingerprint"]).to eq("b41447552cff977d3d98dff4cd282ec2")
       expect(json["severity"]).to eq(CC::Engine::Analyzers::Base::MAJOR)
     end
 
@@ -82,12 +82,12 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
         "path" => "foo.php",
         "lines" => { "begin" => 2, "end" => 8 },
       })
-      expect(json["remediation_points"]).to eq(965_000)
+      expect(json["remediation_points"]).to eq(967000)
       expect(json["other_locations"]).to eq([
         {"path" => "foo.php", "lines" => { "begin" => 10, "end" => 16} },
       ])
-      expect(json["content"]["body"]).to match(/This issue has a mass of 24/)
-      expect(json["fingerprint"]).to eq("8fe741c1e4cccc7226bbf6f0244fc49d")
+      expect(json["content"]["body"]).to match(/This issue has a mass of 28/)
+      expect(json["fingerprint"]).to eq("c4c0b456f59f109d0a5cfce7d4807935")
     end
 
     it "runs against complex files" do
@@ -238,7 +238,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
           "path" => "foo.php",
           "lines" => { "begin" => 8, "end" => 14 },
         )
-        expect(issue["content"]["body"]).to match(/This issue has a mass of 24/)
+        expect(issue["content"]["body"]).to match(/This issue has a mass of 28/)
       end
 
       it "ignores one-line comments" do
@@ -272,7 +272,7 @@ RSpec.describe CC::Engine::Analyzers::Php::Main, in_tmpdir: true do
           "path" => "foo.php",
           "lines" => { "begin" => 4, "end" => 10 },
         )
-        expect(issue["content"]["body"]).to match(/This issue has a mass of 24/)
+        expect(issue["content"]["body"]).to match(/This issue has a mass of 28/)
       end
     end
   end


### PR DESCRIPTION
As [Bump PHP parser](https://github.com/codeclimate/codeclimate-parser/pull/169) indicates a major update has been done to the main library in charge of parsing php code into AST nodes.

There are some differences between the old and new php parser, the differences are mostly new nodes, as you can check in it's [CHANGELOG](https://github.com/nikic/PHP-Parser/blob/master/CHANGELOG.md). This new nodes have increased the resulting AST depth, which has forced us to modify both the `DEFAULT_MASS_THRESHOLD` and `POINTS_PER_OVERAGE` in order to avoid overwhelming existent users with new issues.

The approach that we have taken for manipulating this constants has been: "Avoid generating new issues for customers". Also, we did research about which was the approach used in the project for this kind of changes and seems like they were very empirical based. Being said that, I propose to try this settings and came back if we have any customer's reports about this.
