### PR TITLE
Python: don't crash on complex-number literals

### DIFF
--- a/lib/cc/engine/analyzers/python/parser.py
+++ b/lib/cc/engine/analyzers/python/parser.py
@@ -7,9 +7,9 @@ def string_type():
 
 def num_types():
     if PY3:
-        return (int, float, complex)
+        return (int, float)
     else:
-        return (int, float, long, complex)
+        return (int, float, long)
 
 def to_json(node):
     json_ast = {'attributes': {}}
@@ -31,6 +31,10 @@ def cast_value(value):
         return value
     elif PY3 and isinstance(value, bytes):
         return value.decode()
+    elif isinstance(value, complex):
+        # Complex numbers cannot be serialised directly.  Ruby's to_json
+        # handles this by string-ifying the numbers, so we do similarly here.
+        return str(complex)
     elif isinstance(value, num_types()):
         if abs(value) == 1e3000:
             return cast_infinity(value)


### PR DESCRIPTION
This fixes #363: crashing on complex-number literals in Python 2 and 3.  I modified the JSON serialiser to string-ify complex numbers, rather than passing them directly as numeric values.  That's perhaps not 100% ideal, but it's the same as the behaviour of Ruby's `to_json` method.  I've added a test that the behaviour works, as well.

Running `codeclimate analyze` on the same test file in issue #363 with the same settings (`mass_threshold: 1`) now produces the expected output in both Python 2 and Python 3:
```
Starting analysis
Running duplication: Done!

== complex.py (3 issues) ==
1-2: Similar blocks of code found in 3 locations. Consider refactoring. [duplication]
4-5: Similar blocks of code found in 3 locations. Consider refactoring. [duplication]
7-8: Similar blocks of code found in 3 locations. Consider refactoring. [duplication]

Analysis complete! Found 3 issues.
```