### PR TITLE
Qua 543: hide sensitive information and bump cc-parser version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM codeclimate/codeclimate-parser:b871
+FROM codeclimate/codeclimate-parser:b879
 LABEL maintainer="Code Climate <hello@codeclimate.com>"
 
 # Reset from base image

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,5 +24,7 @@ RUN chown -R app:app ./
 
 USER app
 
+# Hide deprecation warnings
+ENV RUBYOPT="-W0"
 ENTRYPOINT ["/usr/src/app/entrypoint"]
 CMD ["/usr/src/app/bin/duplication", "/code", "/config.json"]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,4 +57,4 @@ DEPENDENCIES
   sexp_processor (~> 4.11)
 
 BUNDLED WITH
-   1.10.6
+   2.3.12

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -42,7 +42,7 @@ module CC
           end
         rescue => ex
           if RESCUABLE_ERRORS.map { |klass| ex.instance_of?(klass) }.include?(true)
-            CC.logger.info("Skipping file #{file} due to exception (#{ex.class}): #{ex.message}\n#{ex.backtrace.join("\n")}")
+            CC.logger.info("Skipping file #{file} due to exception (#{ex.class}): #{ex.message}\n")
             nil
           else
             CC.logger.info("#{ex.class} error occurred processing file #{file}: aborting.")


### PR DESCRIPTION
### Purpose
NCC Group audit on our system discovered multiple places where we are revealing sensitive information, like messages containing software versions, which an attacker may use this information to aid further attacks, or as a part of a social engineering attack.

In other words: to increase security.

In this case, Ruby deprecation warnings were revealing some versions used:
```
codeclimate/codeclimate-duplication
13
Parser process id: 13
codeclimate-parser socket not present
waiting 1s...
D, [2022-05-04T13:59:23.882746 #1] DEBUG -- : Processing 0 csharp files concurrency=2
/home/app/.rubies/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/concurrent-ruby-1.0.0/lib/concurrent/atomic/mutex_atomic_fixnum.rb:80: warning: constant ::Fixnum is deprecated
...
```

Also, we were printing exceptions backtrace, which also reveals versions:
```
I, [2022-05-04T18:50:24.607503 #1]  INFO -- : Skipping file ./reports/account_usage_calculator.rb due to exception (RubyParser::SyntaxError): Odd number (2) list for Hash. s(:array, s(:call, nil, :repo_id))
/home/app/.rubies/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/ruby_parser-3.11.0/lib/ruby_parser_extras.rb:51:in `syntax_error'
/home/app/.rubies/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/ruby_parser-3.11.0/lib/ruby18_parser.rb:5708:in `_reduce_493'
/home/app/.rubies/ruby-2.5.1/lib/ruby/2.5.0/racc/parser.rb:259:in `_racc_do_parse_c'
/home/app/.rubies/ruby-2.5.1/lib/ruby/2.5.0/racc/parser.rb:259:in `do_parse'
/home/app/.rubies/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/ruby_parser-3.11.0/lib/ruby_parser_extras.rb:1082:in `block in process'
/home/app/.rubies/ruby-2.5.1/lib/ruby/2.5.0/timeout.rb:93:in `block in timeout'
/home/app/.rubies/ruby-2.5.1/lib/ruby/2.5.0/timeout.rb:33:in `block in catch'
/home/app/.rubies/ruby-2.5.1/lib/ruby/2.5.0/timeout.rb:33:in `catch'
/home/app/.rubies/ruby-2.5.1/lib/ruby/2.5.0/timeout.rb:33:in `catch'
/home/app/.rubies/ruby-2.5.1/lib/ruby/2.5.0/timeout.rb:108:in `timeout'
/home/app/.rubies/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/ruby_parser-3.11.0/lib/ruby_parser_extras.rb:1070:in `process'
/home/app/.rubies/ruby-2.5.1/lib/ruby/gems/2.5.0/gems/ruby_parser-3.11.0/lib/ruby_parser.rb:31:in `block in process'
```

### Description
- Adding the -W0 flag before the ruby server starts silences the warnings (deprecation warnings) -> [Some useful info here](https://mislav.net/2011/06/ruby-verbose-mode)
- Updated bundler version, the older one would raise an error when installing gems while building the docker image.
- Removed the exception backtrace printing as it discloses too much information.
- Updated cc-parser base image to version b879