### PR TITLE
QUA-958: Push images to Dockerhub instead of GCR

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,12 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-      - run: docker login -u _json_key -p "$GCR_JSON_KEY" us.gcr.io
-      - run: make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+      - run: echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
+      - run:
+          name: Push image to Dockerhub
+          command: |
+            make release RELEASE_TAG="b$CIRCLE_BUILD_NUM"
+            make release RELEASE_TAG="$(echo $CIRCLE_BRANCH | grep -oP 'channel/\K[\w\-]+')"
 
 workflows:
   version: 2
@@ -27,6 +31,7 @@ workflows:
     jobs:
       - build_and_test
       - release_images:
+          context: Quality
           requires:
             - build_and_test
           filters:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 IMAGE_NAME ?= codeclimate/codeclimate-duplication
 RELEASE_REGISTRY ?= codeclimate
-RELEASE_TAG ?= latest
+
+ifndef RELEASE_TAG
+override RELEASE_TAG = latest
+endif
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: image test citest release
 
 IMAGE_NAME ?= codeclimate/codeclimate-duplication
+RELEASE_TAG ?= latest
 
 image:
 	docker build --rm -t $(IMAGE_NAME) .
@@ -17,7 +18,6 @@ bundle:
 	  --volume $(PWD):/usr/src/app \
 	  $(IMAGE_NAME) -c "bundle $(BUNDLE_ARGS)"
 
-release: image
-	docker tag $(IMAGE_NAME) \
-		us.gcr.io/code_climate/codeclimate-duplication:$(RELEASE_TAG)
-	docker push us.gcr.io/code_climate/codeclimate-duplication:$(RELEASE_TAG)
+release:
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-coffeelint:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-coffeelint:$(RELEASE_TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .PHONY: image test citest release
 
 IMAGE_NAME ?= codeclimate/codeclimate-duplication
+RELEASE_REGISTRY ?= codeclimate
 RELEASE_TAG ?= latest
 
 image:
@@ -19,5 +20,5 @@ bundle:
 	  $(IMAGE_NAME) -c "bundle $(BUNDLE_ARGS)"
 
 release:
-	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-coffeelint:$(RELEASE_TAG)
-	docker push $(RELEASE_REGISTRY)/codeclimate-coffeelint:$(RELEASE_TAG)
+	docker tag $(IMAGE_NAME) $(RELEASE_REGISTRY)/codeclimate-duplication:$(RELEASE_TAG)
+	docker push $(RELEASE_REGISTRY)/codeclimate-duplication:$(RELEASE_TAG)


### PR DESCRIPTION
Deprecate the pushing of images to GCR in favor of pushing to Dockerhub.