### PR TITLE
Upgrade to latest versions of `flay` and `sexp_processor`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,8 @@
 source "https://rubygems.org"
 
 gem "concurrent-ruby", "~> 1.0.0"
-gem "flay", "~> 2.12"
-gem "sexp_processor", "~> 4.11"
+gem "flay", "~> 2.13.1"
+gem "sexp_processor", "~> 4.17"
 
 gem "codeclimate-parser-client",
   path: "/home/app/codeclimate-parser-client"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,41 +8,39 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.3.0)
-    coderay (1.1.0)
-    concurrent-ruby (1.0.0)
-    diff-lcs (1.2.5)
-    erubis (2.7.0)
+    ast (2.4.2)
+    coderay (1.1.3)
+    concurrent-ruby (1.0.5)
+    diff-lcs (1.5.0)
+    erubi (1.12.0)
     excon (0.99.0)
-    flay (2.12.0)
-      erubis (~> 2.7.0)
+    flay (2.13.1)
+      erubi (~> 1.10)
       path_expander (~> 1.0)
       ruby_parser (~> 3.0)
       sexp_processor (~> 4.0)
-    method_source (0.8.2)
-    path_expander (1.0.3)
-    pry (0.10.3)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rake (10.4.2)
-    rspec (3.3.0)
-      rspec-core (~> 3.3.0)
-      rspec-expectations (~> 3.3.0)
-      rspec-mocks (~> 3.3.0)
-    rspec-core (3.3.2)
-      rspec-support (~> 3.3.0)
-    rspec-expectations (3.3.1)
+    method_source (1.0.0)
+    path_expander (1.1.1)
+    pry (0.14.2)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    rake (13.1.0)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-mocks (3.3.2)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.6)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.3.0)
-    rspec-support (3.3.0)
-    ruby_parser (3.11.0)
-      sexp_processor (~> 4.9)
-    sexp_processor (4.11.0)
-    slop (3.6.0)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.1)
+    ruby_parser (3.20.3)
+      sexp_processor (~> 4.16)
+    sexp_processor (4.17.0)
 
 PLATFORMS
   ruby
@@ -50,11 +48,11 @@ PLATFORMS
 DEPENDENCIES
   codeclimate-parser-client!
   concurrent-ruby (~> 1.0.0)
-  flay (~> 2.12)
+  flay (~> 2.13.1)
   pry
   rake
   rspec
-  sexp_processor (~> 4.11)
+  sexp_processor (~> 4.17)
 
 BUNDLED WITH
    2.4.22

--- a/lib/cc/engine/analyzers/analyzer_base.rb
+++ b/lib/cc/engine/analyzers/analyzer_base.rb
@@ -1,5 +1,51 @@
 # frozen_string_literal: true
 
+# Monkey patch for Parser class
+# used in language analyzers via Sexp::Matcher.parse
+# https://github.com/seattlerb/sexp_processor/blob/master/lib/sexp_matcher.rb
+class Sexp
+  class Matcher < Sexp
+    class Parser
+      def parse_sexp
+        token = next_token
+
+        case token
+        when "(" then
+          parse_list
+        when "[" then
+          parse_cmd
+        when "nil" then
+          nil
+        when /^\d+$/ then
+          token.to_i
+        when "___" then
+          Sexp.___
+        when "_" then
+          Sexp._
+        when %r%^/(.*)/$% then
+          re = $1
+          raise SyntaxError, "Not allowed: /%p/" % [re] unless
+            re =~ /\A([\w()|.*+^$]+)\z/
+          Regexp.new re
+        when /^"(.*)"$/ then
+          $1
+        when /^([A-Z]\w*)$/ then
+          if Object.const_defined?($1)
+              Object.const_get $1
+            else
+              # Handle as a symbol or string
+              $1.to_sym  # or return $1 as a string
+            end
+        when /^:?([\w?!=~-]+)$/ then
+          $1.to_sym
+        else
+          raise SyntaxError, "unhandled token: %p" % [token]
+        end
+      end
+    end
+  end
+end
+
 require "cc/engine/analyzers/parser_error"
 require "cc/engine/analyzers/parser_base"
 require "cc/engine/analyzers/file_list"

--- a/spec/cc/engine/analyzers/ruby/main_spec.rb
+++ b/spec/cc/engine/analyzers/ruby/main_spec.rb
@@ -61,10 +61,10 @@ module CC::Engine::Analyzers
 
         expect(json["location"]).to eq({
           "path" => "foo.rb",
-          "lines" => { "begin" => 2, "end" => 12 },
+          "lines" => { "begin" => 2, "end" => 11 },
         })
         expect(json["other_locations"]).to eq([
-          {"path" => "foo.rb", "lines" => { "begin" => 18, "end" => 28} },
+          {"path" => "foo.rb", "lines" => { "begin" => 18, "end" => 27} },
         ])
       end
 

--- a/spec/cc/engine/analyzers/sexp_lines_spec.rb
+++ b/spec/cc/engine/analyzers/sexp_lines_spec.rb
@@ -18,9 +18,9 @@ module CC::Engine::Analyzers
 
         expect(locations.count).to eq 2
         expect(locations[0].begin_line).to eq(3)
-        expect(locations[0].end_line).to eq(7)
+        expect(locations[0].end_line).to eq(4)
         expect(locations[1].begin_line).to eq(5)
-        expect(locations[1].end_line).to eq(7)
+        expect(locations[1].end_line).to eq(6)
       end
 
       it "gets appropriate locations for hashes" do


### PR DESCRIPTION
This also applies a small monkey patch to the `parse_sexp` method in the
`sexp_processor` gem. This will allow us to continue passing filters to
`Sexp::Matcher.parse` like this:
```
DEFAULT_FILTERS = [
  "(UsingDirective ___)".freeze
].freeze
```